### PR TITLE
Fix: update getUrl type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export type DefaultQueryStringMap = {
 };
 
 export interface UrlHelpers {
-  getUrl: () => string;
+  getUrl: () => string | undefined;
   setUrl: (newUrlWithEncodedState: string) => void;
   getStateFromUrl: (urlString: string) => RequestConfigs;
   getUrlFromState: (state: RequestConfigs, options: QueryParamEncodingOptions) => string;


### PR DESCRIPTION
Updating the types here to match our new, server-side compatible, getUrl implementation