### PR TITLE
[CI-4166] OS PLP UI - Remove category breadcrumbs from Browse PLP

### DIFF
--- a/src/components/CioPlpGrid/CioPlpGrid.tsx
+++ b/src/components/CioPlpGrid/CioPlpGrid.tsx
@@ -5,7 +5,6 @@ import {
 } from '@constructor-io/constructorio-client-javascript/lib/types';
 import ProductCard from '../ProductCard';
 import Filters from '../Filters';
-import Groups, { GroupsProps } from '../Groups';
 import FiltersIcon from '../Filters/FiltersIcon';
 import MobileModal from '../MobileModal';
 import Sort from '../Sort';
@@ -42,10 +41,6 @@ export type CioPlpGridProps = {
    * No configurations available yet.
    */
   filterConfigs?: Omit<UseFilterProps, 'facets'>;
-  /**
-   * Used to set the `initialNumOptions` to limit the number of options shown initially.
-   */
-  groupsConfigs?: Omit<GroupsProps, 'groups'>;
 };
 
 export type CioPlpGridWithRenderProps = IncludeRenderProps<
@@ -61,7 +56,6 @@ export default function CioPlpGrid(props: CioPlpGridWithRenderProps) {
     filterConfigs,
     sortConfigs,
     paginationConfigs,
-    groupsConfigs,
     children,
   } = props;
   const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -133,7 +127,6 @@ export default function CioPlpGrid(props: CioPlpGridWithRenderProps) {
               {data.response?.results?.length ? (
                 <div className='cio-plp-grid'>
                   <div className='cio-filters-container cio-large-screen-only'>
-                    <Groups groups={data.response.groups} {...groupsConfigs} />
                     <Filters facets={filters.facets} {...filterConfigs} />
                   </div>
                   <div

--- a/src/hooks/useCioPlp.ts
+++ b/src/hooks/useCioPlp.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PlpContextValue, PlpFacet, PlpItemGroup, PlpSortOption } from '../types';
+import { PlpContextValue, PlpFacet, PlpSortOption } from '../types';
 import { useCioPlpContext } from './useCioPlpContext';
 import useSearchResults, { UseSearchResultsProps } from './useSearchResults';
 import useFilter, { UseFilterProps } from './useFilter';
@@ -13,7 +13,6 @@ import {
   checkIsSearchPage,
 } from '../utils';
 import useBrowseResults, { UseBrowseResultsProps } from './useBrowseResults';
-import useGroups, { UseGroupProps } from './useGroups';
 import useRequestConfigs from './useRequestConfigs';
 
 export interface UseCioPlpHook extends PlpContextValue {}
@@ -32,10 +31,6 @@ export type UseCioPlpProps = UseSearchResultsProps &
      * No configurations available yet.
      */
     filterConfigs?: Omit<UseFilterProps, 'facets'>;
-    /**
-     * Used to set the `initialNumOptions` to limit the number of options shown initially.
-     */
-    groupsConfigs?: Omit<UseGroupProps, 'groups'>;
   };
 
 export default function useCioPlp(props: UseCioPlpProps = {}) {
@@ -45,7 +40,6 @@ export default function useCioPlp(props: UseCioPlpProps = {}) {
     paginationConfigs = {},
     sortConfigs = {},
     filterConfigs = {},
-    groupsConfigs = {},
   } = props;
   const contextValue = useCioPlpContext();
 
@@ -80,7 +74,6 @@ export default function useCioPlp(props: UseCioPlpProps = {}) {
   const [totalNumResults, setTotalNumResults] = useState(
     () => coalesceResponse()?.totalNumResults || 0,
   );
-  const [rawGroups, setGroups] = useState<Array<PlpItemGroup>>(coalesceResponse()?.groups || []);
 
   const refetch = () => {
     const currentRequestConfigs = getRequestConfigs();
@@ -102,19 +95,16 @@ export default function useCioPlp(props: UseCioPlpProps = {}) {
       setFacets(search.data.response.facets);
       setSortOptions(search.data.response.sortOptions);
       setTotalNumResults(search.data.response.totalNumResults);
-      setGroups(search.data.response.groups);
     } else if (isBrowsePage && isPlpBrowseDataResults(browse.data)) {
       setFacets(browse.data.response.facets);
       setSortOptions(browse.data.response.sortOptions);
       setTotalNumResults(browse.data.response.totalNumResults);
-      setGroups(browse.data.response.groups);
     }
   }, [search.data, isSearchPage, browse.data, isBrowsePage]);
 
   const filters = useFilter({ facets, ...filterConfigs });
   const sort = useSort({ sortOptions, ...sortConfigs });
   const pagination = usePagination({ totalNumResults, ...paginationConfigs });
-  const groups = useGroups({ groups: rawGroups, ...groupsConfigs });
 
   return {
     isSearchPage,
@@ -128,6 +118,5 @@ export default function useCioPlp(props: UseCioPlpProps = {}) {
     filters,
     sort,
     pagination,
-    groups,
   };
 }


### PR DESCRIPTION
### Definition of done:

- [x] Remove the category breadcrumbs from Browse PLP

    * Groups component in CioPlpGrid.tsx

- [ ] Ensure that the filter display is updates the Breadcrumb component. Currently, the Breadcrumb component may be lose in the process of navigation.
    * Waiting for changes to breadcrumb to merged in https://github.com/Constructor-io/constructorio-ui-plp/pull/128 