### PR TITLE
[CI-4338] Fix Sort Component Re-render upon Receiving Results

### DIFF
--- a/spec/hooks/useCioPlp/useCioPlp.test.tsx
+++ b/spec/hooks/useCioPlp/useCioPlp.test.tsx
@@ -83,7 +83,12 @@ describe('Testing Hook: useCioPlp', () => {
       expect(groups.optionsToRender.length).not.toEqual(0);
       expect(pagination.currentPage).toEqual(1);
       expect(pagination.totalPages).toEqual(18);
-      expect(sort.selectedSort).toEqual(null);
+      expect(sort.selectedSort).toEqual({
+        displayName: 'Relevance',
+        sortBy: 'relevance',
+        sortOrder: 'descending',
+        status: 'selected',
+      });
 
       expect(typeof filters.setFilter).toEqual('function');
       expect(typeof pagination.goToPage).toEqual('function');

--- a/spec/hooks/useSort/useSort.test.js
+++ b/spec/hooks/useSort/useSort.test.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { renderHook, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import useSort from '../../../src/hooks/useSort';
 import { transformSearchResponse } from '../../../src/utils/transformers';
 import mockSearchResponse from '../../local_examples/apiSearchResponse.json';
@@ -96,6 +97,34 @@ describe('Testing Hook: useSort', () => {
       expect(selectedSort.sortBy).toEqual('item_name');
       expect(selectedSort.sortOrder).toEqual('descending');
       expect(selectedSort.displayName).toEqual('Name Z-A');
+    });
+  });
+
+  it.only('Should reflect the selected sort_option on page reload/component rerender', async () => {
+    function TestUseSort() {
+      // sortOptions will be an empty array when the page is first loading
+      const [sortOptions, setSortOptions] = useState([]);
+      const { selectedSort } = useSort({ sortOptions });
+
+      return { selectedSort, setSortOptions };
+    }
+
+    let firstRun = true;
+    const { result } = renderHookWithCioPlp(() => TestUseSort());
+
+    await waitFor(() => {
+      const {
+        current: { selectedSort, setSortOptions },
+      } = result;
+
+      if (firstRun) {
+        // When the page finishes loading, the sortOptions object will be updated
+        setSortOptions(useSortOptionsProps.sortOptions);
+        firstRun = false;
+      }
+
+      expect(selectedSort.sortBy).toEqual('relevance');
+      expect(selectedSort.sortOrder).toEqual('descending');
     });
   });
 });

--- a/src/components/Sort/Sort.tsx
+++ b/src/components/Sort/Sort.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import useSort, { UseSortProps } from '../../hooks/useSort';
-import { IncludeRenderProps, UseSortReturn } from '../../types';
+import { IncludeRenderProps, PlpSortOption, UseSortReturn } from '../../types';
 import MobileModal from '../MobileModal';
 
 export type SortProps = UseSortProps & {
@@ -29,18 +29,24 @@ export default function Sort({
     changeSelectedSort(JSON.parse(event.target.value));
   };
 
+  const isChecked = useCallback(
+    (option: PlpSortOption) =>
+      selectedSort?.sortBy === option.sortBy && selectedSort?.sortOrder === option.sortOrder,
+    [selectedSort],
+  );
+
+  const getOptionId = (option: PlpSortOption) => `${option.sortBy}-${option.sortOrder}`;
+
   const defaultMarkup = sortOptions.map((option) => (
     <label
-      htmlFor={`${option.sortBy}-${option.sortOrder}`}
-      key={`${option.sortBy}-${option.sortOrder}`}>
+      htmlFor={getOptionId(option)}
+      key={`${getOptionId(option)}${isChecked(option) ? '-checked' : ''}`}>
       <input
-        id={`${option.sortBy}-${option.sortOrder}`}
+        id={getOptionId(option)}
         type='radio'
-        name={`${option.sortBy}-${option.sortOrder}`}
+        name={getOptionId(option)}
         value={JSON.stringify(option)}
-        checked={
-          selectedSort?.sortBy === option.sortBy && selectedSort.sortOrder === option.sortOrder
-        }
+        checked={isChecked(option)}
         onChange={handleOptionChange}
       />
       <span>{option.displayName}</span>

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -33,9 +33,7 @@ const useSort = ({ sortOptions }: UseSortProps): UseSortReturn => {
       const defaultSort = sortOptions.find((option) => option.status === 'selected');
       if (defaultSort) setSelectedSort(defaultSort);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortBy, sortOrder]);
+  }, [sortBy, sortOrder, sortOptions]);
 
   const changeSelectedSort = (sortOption: PlpSortOption) => {
     setSelectedSort(sortOption);


### PR DESCRIPTION
# Fix Description
The `useSort` hook is not correctly updating when new sort options are reactively updated due to missing dependencies in the `useEffect` implementation.

The issue occurs when the page reloads/request is refetched and the initial list of `sortOptions` provided to the hook is an empty list.

# Pull Request Checklist

Before you submit a pull request, please make sure you have to following:

- [ ] I have added or updated TypeScript types for my changes, ensuring they are compatible with the existing codebase.
- [ ] I have added JSDoc comments to my TypeScript definitions for improved documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added any necessary documentation (if appropriate).
- [x] I have made sure my PR is up-to-date with the main branch.

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] TypeScript type definitions update
- [ ] Other... Please describe:
