### PR TITLE
[CI-4365] Add Option to Pass Logged in User Id and other parameters to the JS-Client

### DIFF
--- a/spec/hooks/useCioPlpProvider/useCioPlpProvider.server.test.js
+++ b/spec/hooks/useCioPlpProvider/useCioPlpProvider.server.test.js
@@ -1,0 +1,51 @@
+/* eslint-disable react/jsx-filename-extension */
+import useCioPlpProvider from '../../../src/hooks/useCioPlpProvider';
+import { renderHookServerSide } from '../../test-utils.server';
+
+describe('Testing Hook on the server: useCioPlpProvider', () => {
+  beforeEach(() => {
+    const spy = jest.spyOn(console, 'error');
+    spy.mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Should return client when custom client is provided', () => {
+    const mockClient = { tracker: () => {} };
+    const { result } = renderHookServerSide(({ cioClient }) => useCioPlpProvider({ cioClient }), {
+      initialProps: { cioClient: mockClient },
+    });
+
+    expect(result.cioClient).toBe(mockClient);
+  });
+
+  it('Should return when clientOptions are provided', () => {
+    const key = 'xx';
+    const clientOptions = {
+      serviceUrl: 'https://special.cnstrc.com',
+      quizzesServiceUrl: 'https://quizzes.cnstrc.com',
+      sessionId: 1,
+      clientId: 'id-1',
+      userId: 'ui-1',
+      segments: ['segment-1', 'segment-2'],
+      testCells: { test: 'cell' },
+      fetch: 'mock-fetch-fn',
+      trackingSendDelay: 400,
+      sendReferrerWithTrackingEvents: true,
+      beaconMode: false,
+      eventDispatcher: undefined,
+      networkParameters: { timeout: 1000 },
+    };
+
+    const { result } = renderHookServerSide(
+      ({ apiKey, options }) => useCioPlpProvider({ apiKey, options }),
+      {
+        initialProps: { apiKey: key, options: clientOptions },
+      },
+    );
+
+    expect(result.cioClient).toBe(null);
+  });
+});

--- a/spec/hooks/useCioPlpProvider/useCioPlpProvider.server.test.js
+++ b/spec/hooks/useCioPlpProvider/useCioPlpProvider.server.test.js
@@ -22,7 +22,7 @@ describe('Testing Hook on the server: useCioPlpProvider', () => {
   });
 
   it('Should return when clientOptions are provided', () => {
-    const key = 'xx';
+    const key = 'test-key';
     const clientOptions = {
       serviceUrl: 'https://special.cnstrc.com',
       quizzesServiceUrl: 'https://quizzes.cnstrc.com',

--- a/spec/hooks/useCioPlpProvider/useCioPlpProvider.test.js
+++ b/spec/hooks/useCioPlpProvider/useCioPlpProvider.test.js
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useCioPlpProvider from '../../../src/hooks/useCioPlpProvider';
+
+describe('Testing Hook: useCioPlpProvider', () => {
+  it('Should return client when custom client is provided', () => {
+    const mockClient = { tracker: () => {} };
+    const { result } = renderHook(({ cioClient }) => useCioPlpProvider({ cioClient }), {
+      initialProps: { cioClient: mockClient },
+    });
+
+    expect(result.current.cioClient).toBe(mockClient);
+  });
+
+  test('Should pass custom client options if set', () => {
+    const key = 'test-key';
+    const clientOptions = {
+      serviceUrl: 'https://special.cnstrc.com',
+      quizzesServiceUrl: 'https://quizzes.cnstrc.com',
+      sessionId: 1,
+      clientId: 'id-1',
+      userId: 'ui-1',
+      segments: ['segment-1', 'segment-2'],
+      testCells: { test: 'cell' },
+      fetch: 'mock-fetch-fn',
+      trackingSendDelay: 400,
+      sendReferrerWithTrackingEvents: true,
+      beaconMode: false,
+      eventDispatcher: undefined,
+      networkParameters: { timeout: 1000 },
+    };
+
+    const { result } = renderHook(
+      ({ apiKey, options }) => useCioPlpProvider({ apiKey, cioClientOptions: options }),
+      {
+        initialProps: { apiKey: key, options: clientOptions },
+      },
+    );
+
+    const { cioClientOptions } = result.current;
+    expect(cioClientOptions).toEqual({
+      ...clientOptions,
+    });
+  });
+
+  test('Should update client if setCioClientOptions is called', async () => {
+    const key = 'xx';
+
+    const { result } = renderHook(({ apiKey }) => useCioPlpProvider({ apiKey }), {
+      initialProps: { apiKey: key },
+    });
+
+    let firstRun = true;
+    await waitFor(() => {
+      const { cioClientOptions, setCioClientOptions, cioClient } = result.current;
+
+      if (firstRun) {
+        setCioClientOptions({ userId: 'test' });
+        firstRun = false;
+      }
+
+      expect(cioClientOptions.userId).toEqual('test');
+      expect(cioClient.options.userId).toEqual('test');
+    });
+  });
+});

--- a/spec/hooks/useCioPlpProvider/useCioPlpProvider.test.js
+++ b/spec/hooks/useCioPlpProvider/useCioPlpProvider.test.js
@@ -43,7 +43,7 @@ describe('Testing Hook: useCioPlpProvider', () => {
   });
 
   test('Should update client if setCioClientOptions is called', async () => {
-    const key = 'xx';
+    const key = 'test-key';
 
     const { result } = renderHook(({ apiKey }) => useCioPlpProvider({ apiKey }), {
       initialProps: { apiKey: key },

--- a/src/hooks/useCioPlpProvider.ts
+++ b/src/hooks/useCioPlpProvider.ts
@@ -16,9 +16,10 @@ export default function useCioPlpProvider(
     urlHelpers,
     staticRequestConfigs = {},
     cioClient: customCioClient,
+    cioClientOptions: customCioClientOptions = {},
   } = props;
 
-  const [cioClientOptions, setCioClientOptions] = useState({});
+  const [cioClientOptions, setCioClientOptions] = useState(customCioClientOptions);
   const cioClient = useCioClient({ apiKey, cioClient: customCioClient, options: cioClientOptions });
 
   const contextValue = useMemo(

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,7 @@ export interface PlpBrowseResponse extends PlpSearchResponse {}
 export interface CioPlpProviderProps {
   apiKey: string;
   cioClient?: Nullable<ConstructorIOClient>;
+  cioClientOptions?: Omit<ConstructorClientOptions, 'apiKey' | 'version'>;
   formatters?: Partial<Formatters>;
   callbacks?: Partial<Callbacks>;
   itemFieldGetters?: Partial<ItemFieldGetters>;


### PR DESCRIPTION
# Description
Passing client options directly from the parent component `CioPlp` isn't possible currently. This PR addresses that by exposing a prop that allows users to pass client options such as `userId` and `testCells` when instantiating the component.

```tsx
// Example instantiation

function MyPage() {
  const myCustomOptions = { userId: 'logged_in_id', testCells: { constructorio: 'control' } }

  return <CioPlp apiKey="MY_API_KEY" cioClientOptions={myCustomOptions} />
}
```

# Pull Request Checklist

Before you submit a pull request, please make sure you have to following:

- [x] I have added or updated TypeScript types for my changes, ensuring they are compatible with the existing codebase.
- [ ] I have added JSDoc comments to my TypeScript definitions for improved documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added any necessary documentation (if appropriate).
- [ ] I have made sure my PR is up-to-date with the main branch.

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [x] TypeScript type definitions update
- [ ] Other... Please describe:
