### PR TITLE
[CI-4381] Fix clicking on ProductSwatch initiating a redirect

### DIFF
--- a/src/components/ProductSwatch/ProductSwatch.tsx
+++ b/src/components/ProductSwatch/ProductSwatch.tsx
@@ -24,11 +24,17 @@ export default function ProductSwatch(props: ProductSwatchProps) {
   } = context;
 
   const swatchClickHandler = (e: React.MouseEvent, clickedSwatch: SwatchItem) => {
+    // Stop the event from bubbling up to the parent element
+    e.stopPropagation();
+
     selectVariation(clickedSwatch);
 
     if (onSwatchClick) {
       onSwatchClick(e, clickedSwatch);
     }
+
+    // Prevent link navigation
+    e.preventDefault();
   };
 
   return (


### PR DESCRIPTION
### Context
* Right now, clicking on a product swatch redirects to the PDP because the product card is basically an anchor tag, and clicking on that <a> tag redirects to the PDP

* We need to fix this behavior such that click on the product swatches doesn't redirect

* To see an example of this issue, you can go to this [Sandbox](https://codesandbox.io/p/sandbox/interesting-ully-xvwhww) and add `/collections/cio-outdoor-living` to the path in the sandbox

### Definition of Done

- [ ] Fix the behavior such that click on the product swatches doesn't redirect

- [X] Add documentation in swatch handler hooks to enable customers to utilise