### PR TITLE
[CI-4410] Send correct variationId to onAddToCart callback, add test

### DIFF
--- a/spec/components/ProductCard/productCard.test.js
+++ b/spec/components/ProductCard/productCard.test.js
@@ -93,6 +93,25 @@ describe('Testing Component: ProductCard', () => {
     expect(contextOnAddToCart).toHaveBeenCalledTimes(1);
   });
 
+  test('Should run custom onAddToCart handler if overridden at the CioPlp provider level', () => {
+    const contextOnAddToCart = jest.fn();
+    const item = transformResultItem(testItem);
+    const testVariationId = item.variations[1].variationId;
+    render(
+      <CioPlp apiKey={DEMO_API_KEY} callbacks={{ onAddToCart: contextOnAddToCart }}>
+        <ProductCard item={item} />
+      </CioPlp>,
+    );
+
+    fireEvent.click(screen.getByTestId(`cio-swatch-${testVariationId}`));
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    expect(contextOnAddToCart).toHaveBeenCalledTimes(1);
+    expect(contextOnAddToCart).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ variationId: testVariationId }),
+    );
+  });
+
   test('Should render renderProps argument', () => {
     render(
       <CioPlp apiKey={DEMO_API_KEY}>

--- a/spec/components/ProductCard/productCard.test.js
+++ b/spec/components/ProductCard/productCard.test.js
@@ -134,6 +134,25 @@ describe('Testing Component: ProductCard', () => {
     );
   });
 
+  test('Should not throw an error when calling the custom onAddToCart handler if no variations exist', () => {
+    const contextOnAddToCart = jest.fn();
+    const { variations, variationId, ...item } = transformResultItem(testItem);
+
+    render(
+      <CioPlp apiKey={DEMO_API_KEY} callbacks={{ onAddToCart: contextOnAddToCart }}>
+        <ProductCard item={item} />
+      </CioPlp>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    expect(contextOnAddToCart).toHaveBeenCalledTimes(1);
+    expect(contextOnAddToCart).toHaveBeenCalledWith(
+      expect.any(Object), // Event
+      expect.objectContaining(item),
+      undefined,
+    );
+  });
+
   test('Should render renderProps argument', () => {
     render(
       <CioPlp apiKey={DEMO_API_KEY}>

--- a/spec/components/ProductCard/productCard.test.js
+++ b/spec/components/ProductCard/productCard.test.js
@@ -93,22 +93,44 @@ describe('Testing Component: ProductCard', () => {
     expect(contextOnAddToCart).toHaveBeenCalledTimes(1);
   });
 
-  test('Should run custom onAddToCart handler if overridden at the CioPlp provider level', () => {
+  test('Should pass the expected props to the custom onAddToCart handler if defined', () => {
     const contextOnAddToCart = jest.fn();
     const item = transformResultItem(testItem);
-    const testVariationId = item.variations[1].variationId;
+    const testSelectedVariation = item.variations[0];
+
     render(
       <CioPlp apiKey={DEMO_API_KEY} callbacks={{ onAddToCart: contextOnAddToCart }}>
         <ProductCard item={item} />
       </CioPlp>,
     );
 
-    fireEvent.click(screen.getByTestId(`cio-swatch-${testVariationId}`));
     fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
     expect(contextOnAddToCart).toHaveBeenCalledTimes(1);
     expect(contextOnAddToCart).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({ variationId: testVariationId }),
+      expect.any(Object), // Event
+      expect.objectContaining(item),
+      expect.objectContaining(testSelectedVariation),
+    );
+  });
+
+  test('Should pass expected props, including the updated selectedVariation when a swatch has been selected, to the custom onAddToCart handler if defined', () => {
+    const contextOnAddToCart = jest.fn();
+    const item = transformResultItem(testItem);
+    const testSelectedVariation = item.variations[1];
+
+    render(
+      <CioPlp apiKey={DEMO_API_KEY} callbacks={{ onAddToCart: contextOnAddToCart }}>
+        <ProductCard item={item} />
+      </CioPlp>,
+    );
+
+    fireEvent.click(screen.getByTestId(`cio-swatch-${testSelectedVariation.variationId}`));
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    expect(contextOnAddToCart).toHaveBeenCalledTimes(1);
+    expect(contextOnAddToCart).toHaveBeenCalledWith(
+      expect.any(Object), // Event
+      expect.objectContaining(item),
+      expect.objectContaining(testSelectedVariation),
     );
   });
 

--- a/src/components/ProductSwatch/ProductSwatch.tsx
+++ b/src/components/ProductSwatch/ProductSwatch.tsx
@@ -58,6 +58,7 @@ export default function ProductSwatch(props: ProductSwatchProps) {
                   type='button'
                   key={swatch.variationId}
                   data-cnstrc-variation-id={swatch.variationId}
+                  data-testid={`cio-swatch-${swatch.variationId}`}
                   className='cio-swatch-button cio-swatch-item'
                   onClick={(e) => swatchClickHandler(e, swatch)}
                   style={{

--- a/src/hooks/callbacks/useOnAddToCart.ts
+++ b/src/hooks/callbacks/useOnAddToCart.ts
@@ -3,12 +3,12 @@ import React, { useCallback } from 'react';
 import ConstructorIO from '@constructor-io/constructorio-client-javascript';
 import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/types';
 
-import { Item } from '../../types';
+import { Callbacks, Item, Variation } from '../../types';
 import useRequestConfigs from '../useRequestConfigs';
 
 export default function useOnAddToCart(
   cioClient: Nullable<ConstructorIO>,
-  callback?: (event: React.MouseEvent, item: Item) => void,
+  callback?: Callbacks['onAddToCart'],
 ) {
   const { getRequestConfigs } = useRequestConfigs();
   const requestConfigs = getRequestConfigs();
@@ -21,6 +21,7 @@ export default function useOnAddToCart(
     (event: React.MouseEvent, item: Item, revenue?: number, selectedVariationId?: string) => {
       const { itemId, itemName, variationId } = item;
       const { query, section } = requestConfigs;
+      let selectedVariation: Variation | undefined;
 
       if (cioClient) {
         cioClient.tracker.trackConversion(query, {
@@ -32,7 +33,13 @@ export default function useOnAddToCart(
         });
       }
 
-      if (callback) callback(event, { ...item, variationId: selectedVariationId || variationId });
+      if (selectedVariationId) {
+        selectedVariation = item.variations?.filter(
+          (variation) => variation.variationId === selectedVariationId,
+        )?.[0];
+      }
+
+      if (callback) callback(event, item, selectedVariation);
 
       event.preventDefault();
       event.stopPropagation();

--- a/src/hooks/callbacks/useOnAddToCart.ts
+++ b/src/hooks/callbacks/useOnAddToCart.ts
@@ -32,7 +32,7 @@ export default function useOnAddToCart(
         });
       }
 
-      if (callback) callback(event, item);
+      if (callback) callback(event, { ...item, variationId: selectedVariationId || variationId });
 
       event.preventDefault();
       event.stopPropagation();

--- a/src/stories/components/CioPlp/CioPlpProps.md
+++ b/src/stories/components/CioPlp/CioPlpProps.md
@@ -16,12 +16,12 @@ Formatters will be used to modify how certain fields are rendered
 
 Callbacks will be composed with the library's internal tracking calls for a given event
 
-| property           | type                                                       | description                            |
-| ------------------ | ---------------------------------------------------------- | -------------------------------------- |
-| onAddToCart        | `(event: React.MouseEvent, item: Item) => void`            | Product add to cart callback function  |
-| onProductCardClick | `(event: React.MouseEvent, item: Item) => void`            | Product click callback function        |
-| onSwatchClick      | `(e: React.MouseEvent, clickedSwatch: SwatchItem) => void` | Product swatch click callback function |
-| onRedirect         | `(url: string) => void`                                    | Redirect callback function             |
+| property           | type                                                                           | description                            |
+| ------------------ | ------------------------------------------------------------------------------ | -------------------------------------- |
+| onAddToCart        | `(event: React.MouseEvent, item: Item, selectedVariation?: Variation) => void` | Product add to cart callback function  |
+| onProductCardClick | `(event: React.MouseEvent, item: Item) => void`                                | Product click callback function        |
+| onSwatchClick      | `(e: React.MouseEvent, clickedSwatch: SwatchItem) => void`                     | Product swatch click callback function |
+| onRedirect         | `(url: string) => void`                                                        | Redirect callback function             |
 
 <br>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface Formatters {
 }
 
 export interface Callbacks {
-  onAddToCart?: (event: React.MouseEvent, item: Item) => void;
+  onAddToCart?: (event: React.MouseEvent, item: Item, selectedVariation?: Variation) => void;
   onProductCardClick?: (event: React.MouseEvent, item: Item) => void;
   onSwatchClick?: (event: React.MouseEvent, swatch: SwatchItem) => void;
   onRedirect?: (url: string) => void;


### PR DESCRIPTION
This PR modifies the expected call signature for the custom `onAddToCart` callback:
```
(event, item) => void   -->   (event, item, selectedVariation?) => void
```

Since this modification only adds an optional parameter, it is a backwards compatible change.