### PR TITLE
[CDX-164] Update getStateFromUrl 

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -19,4 +19,5 @@ jobs:
         with:
           node-version: '18.13.0'
       - name: Spell check
-        run: npx cspell "**/*.{ts,tsx}"
+        run: npx cspell@v8.19.4 "**/*.js"
+

--- a/spec/hooks/useRequestConfigs/useRequestConfigs.test.tsx
+++ b/spec/hooks/useRequestConfigs/useRequestConfigs.test.tsx
@@ -66,7 +66,7 @@ describe('Testing Hook: useRequestConfigs', () => {
 
   it('Should return configurations set in the URL path/query parameters', () => {
     function TestReactComponent() {
-      window.location.href = testUrl;
+      window.location.href = testUrl.replace('q=item', '');
       const { getRequestConfigs } = useRequestConfigs();
       const requestConfigs = getRequestConfigs();
       const { fmtOptions, qsParam, preFilterExpression, variationsMap, ...sampleRequestState } =
@@ -75,7 +75,7 @@ describe('Testing Hook: useRequestConfigs', () => {
       sampleRequestState.filterName = 'group_id';
       sampleRequestState.filterValue = 'Styles';
 
-      expect(requestConfigs).toEqual(sampleRequestState);
+      expect(requestConfigs).toEqual({ ...sampleRequestState, query: undefined });
 
       return <div>test</div>;
     }

--- a/spec/urlHelpers.test.tsx
+++ b/spec/urlHelpers.test.tsx
@@ -144,11 +144,18 @@ describe('Testing Default UrlHelpers: getStateFromUrl', () => {
     expect(typeof (state as any).qsParam).toBe('undefined');
   });
 
-  test('getBrowseGroup should get the last path name as the group_id', () => {
-    const mockUrl = 'https://example.com/a/random/lastPathName?q=3&randomQuery=[true,%20false]';
+  test('getBrowseGroup should get the last path name as the group_id when no query parameter exists', () => {
+    const mockUrl = 'https://example.com/a/random/lastPathName';
     const { filterName, filterValue } = getStateFromUrl(mockUrl);
     expect(filterName).toBe('group_id');
     expect(filterValue).toBe('lastPathName');
+  });
+
+  test('getBrowseGroup should not set group_id when query parameter exists', () => {
+    const mockUrl = 'https://example.com/a/random/lastPathName?q=searchterm';
+    const { filterName, filterValue } = getStateFromUrl(mockUrl);
+    expect(filterName).toBeUndefined();
+    expect(filterValue).toBeUndefined();
   });
 });
 

--- a/spec/urlHelpers.test.tsx
+++ b/spec/urlHelpers.test.tsx
@@ -47,7 +47,10 @@ describe('Testing Default UrlHelpers: getUrlFromState', () => {
   });
 
   test('Should not encode parameters not defined in defaultQueryStringMap', () => {
-    const urlString = getUrlFromState(testRequestState as RequestConfigs, 'https://www.example.com/a/random/path');
+    const urlString = getUrlFromState(
+      testRequestState as RequestConfigs,
+      'https://www.example.com/a/random/path',
+    );
     const url = new URL(urlString);
     const params = url.searchParams;
 
@@ -72,9 +75,9 @@ describe('Testing Default UrlHelpers: getUrlFromState', () => {
   test('Should update pathname when filterName and filterValue are provided', () => {
     const url = new URL(
       getUrlFromState(testRequestState as RequestConfigs, 'https://www.example.com/a/random/path'),
-    )
+    );
 
-    expect(url.pathname).toBe('/group_id/Styles');    
+    expect(url.pathname).toBe('/group_id/Styles');
   });
 
   test('Should handle empty pathname correctly', () => {
@@ -87,8 +90,8 @@ describe('Testing Default UrlHelpers: getUrlFromState', () => {
   test('Should replace existing group_id in pathname', () => {
     const url = new URL(
       getUrlFromState(
-        testRequestState as RequestConfigs, 
-        'https://www.example.com/path/group_id/old-value'
+        testRequestState as RequestConfigs,
+        'https://www.example.com/path/group_id/old-value',
       ),
     );
     expect(url.pathname).toBe('/path/group_id/Styles');
@@ -98,7 +101,7 @@ describe('Testing Default UrlHelpers: getUrlFromState', () => {
     const url = new URL(
       getUrlFromState(
         { ...testRequestState, filterName: 'collection_id' } as RequestConfigs,
-        'https://www.example.com/path/collection_id/old-value'
+        'https://www.example.com/path/collection_id/old-value',
       ),
     );
     expect(url.pathname).toBe('/path/collection_id/Styles');
@@ -107,8 +110,11 @@ describe('Testing Default UrlHelpers: getUrlFromState', () => {
   test('Should retain pathname when filterName and filterValue are not provided', () => {
     const { filterName, filterValue, ...testRequestStateWithoutFilters } = testRequestState;
     const url = new URL(
-      getUrlFromState(testRequestStateWithoutFilters as RequestConfigs, 'https://www.example.com/a/random/path'),
-    )
+      getUrlFromState(
+        testRequestStateWithoutFilters as RequestConfigs,
+        'https://www.example.com/a/random/path',
+      ),
+    );
 
     expect(url.pathname).toBe('/a/random/path');
   });
@@ -144,14 +150,14 @@ describe('Testing Default UrlHelpers: getStateFromUrl', () => {
     expect(typeof (state as any).qsParam).toBe('undefined');
   });
 
-  test('getBrowseGroup should get the last path name as the group_id when no query parameter exists', () => {
+  test('getStateFromUrl should get the last path name as the group_id when no query parameter exists', () => {
     const mockUrl = 'https://example.com/a/random/lastPathName';
     const { filterName, filterValue } = getStateFromUrl(mockUrl);
     expect(filterName).toBe('group_id');
     expect(filterValue).toBe('lastPathName');
   });
 
-  test('getBrowseGroup should not set group_id when query parameter exists', () => {
+  test('getStateFromUrl should not set group_id when query parameter exists', () => {
     const mockUrl = 'https://example.com/a/random/lastPathName?q=searchterm';
     const { filterName, filterValue } = getStateFromUrl(mockUrl);
     expect(filterName).toBeUndefined();

--- a/src/stories/components/CioPlp/CioPlpProps.md
+++ b/src/stories/components/CioPlp/CioPlpProps.md
@@ -85,10 +85,11 @@ Url Helpers are used for managing the url and request state. These functions def
     const urlObject = new URL(url);
     const urlParams = urlObject.searchParams;
     const paths = decodeURI(urlObject?.pathname)?.split('/');
+    const query = urlParams.get(defaultQueryStringMap.query);
     let filterName;
     let filterValue;
 
-    if (paths.length > 0) {
+    if (!query && paths.length > 0) {
       filterName = 'group_id';
       filterValue = paths[paths.length - 1];
     }

--- a/src/utils/urlHelpers.ts
+++ b/src/utils/urlHelpers.ts
@@ -60,10 +60,11 @@ export function getStateFromUrl(url: string): RequestConfigs {
   const urlObject = new URL(url);
   const urlParams = urlObject.searchParams;
   const paths = decodeURI(urlObject?.pathname)?.split('/');
+  const query = urlParams.get(defaultQueryStringMap.query);
   let filterName: string | undefined;
   let filterValue: string | undefined;
 
-  if (paths.length > 0) {
+  if (!query && paths.length > 0) {
     filterName = 'group_id';
     filterValue = paths[paths.length - 1];
   }


### PR DESCRIPTION
URLs like a.com/search or a.com/b/search could be parsed as browse pages leading to issues. To prevent this, update the getStateFromUrl function to look for the defaultQueryStringMap.query parameter and make that the top priority to determine if the page is a search page. The browse parsing logic should only come after that check

# Pull Request Checklist

Before you submit a pull request, please make sure you have to following:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made sure my PR is up-to-date with the main branch.

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
