### PR TITLE
[CDX-169] Support Sale pricing

### DIFF
--- a/spec/hooks/useProductInfo/useProductInfo.test.js
+++ b/spec/hooks/useProductInfo/useProductInfo.test.js
@@ -48,15 +48,24 @@ describe('Testing Hook: useProductInfo', () => {
 
     await waitFor(() => {
       const {
-        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice, itemId },
+        current: {
+          productSwatch,
+          itemName,
+          itemImageUrl,
+          itemUrl,
+          itemPrice,
+          itemId,
+          itemSalePrice,
+        },
       } = result;
 
       expect(productSwatch).not.toBeNull();
-      expect(itemId).toEqual(transformedItem.itemId);
-      expect(itemName).toEqual(transformedItem.itemName);
-      expect(itemImageUrl).toEqual(transformedItem.imageUrl);
-      expect(itemUrl).toEqual(transformedItem.url);
-      expect(itemPrice).toEqual(transformedItem.data.price);
+      expect(itemId).toEqual(transformedItemWithSalePrice.itemId);
+      expect(itemName).toEqual(transformedItemWithSalePrice.itemName);
+      expect(itemImageUrl).toEqual(transformedItemWithSalePrice.imageUrl);
+      expect(itemUrl).toEqual(transformedItemWithSalePrice.url);
+      expect(itemPrice).toEqual(transformedItemWithSalePrice.data.price);
+      expect(itemSalePrice).toEqual(transformedItemWithSalePrice.data.salePrice);
     });
   });
 
@@ -67,6 +76,7 @@ describe('Testing Hook: useProductInfo', () => {
           getPrice: () => {},
           getSwatches: () => {},
           getSwatchPreview: () => {},
+          getSalePrice: () => {},
         },
       },
     });
@@ -89,7 +99,7 @@ describe('Testing Hook: useProductInfo', () => {
 
     await waitFor(() => {
       const {
-        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice },
+        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice, itemSalePrice },
       } = result;
       const { selectVariation, swatchList } = productSwatch;
       selectVariation(swatchList[1]);
@@ -98,29 +108,36 @@ describe('Testing Hook: useProductInfo', () => {
       expect(itemImageUrl).toEqual(swatchList[1].imageUrl || transformedItem.imageUrl);
       expect(itemUrl).toEqual(swatchList[1].url || transformedItem.url);
       expect(itemPrice).toEqual(swatchList[1].price || transformedItem.data.price);
+      expect(itemSalePrice).toEqual(swatchList[1].salePrice || transformedItem.data.salePrice);
     });
   });
 
   it('Should return nothing properly with getters that throw errors', async () => {
-    const { result } = renderHookWithCioPlp(() => useProductInfo({ item: transformedItem }), {
-      initialProps: {
-        itemFieldGetters: {
-          getPrice: () => {
-            throw new Error();
-          },
-          getSwatches: () => {
-            throw new Error();
-          },
-          getSwatchPreview: () => {
-            throw new Error();
+    const { result } = renderHookWithCioPlp(
+      () => useProductInfo({ item: transformedItemWithSalePrice }),
+      {
+        initialProps: {
+          itemFieldGetters: {
+            getPrice: () => {
+              throw new Error();
+            },
+            getSwatches: () => {
+              throw new Error();
+            },
+            getSwatchPreview: () => {
+              throw new Error();
+            },
+            getSalePrice: () => {
+              throw new Error();
+            },
           },
         },
       },
-    });
+    );
 
     await waitFor(() => {
       const {
-        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice },
+        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice, itemSalePrice },
       } = result;
 
       expect(productSwatch).not.toBeNull();
@@ -128,6 +145,7 @@ describe('Testing Hook: useProductInfo', () => {
       expect(itemImageUrl).toEqual(transformedItem.imageUrl);
       expect(itemUrl).toEqual(transformedItem.url);
       expect(itemPrice).toBeUndefined();
+      expect(itemSalePrice).toBeUndefined();
     });
   });
 });

--- a/spec/hooks/useProductInfo/useProductInfo.test.js
+++ b/spec/hooks/useProductInfo/useProductInfo.test.js
@@ -41,56 +41,28 @@ describe('Testing Hook: useProductInfo', () => {
     });
   });
 
-  it('Should return include a sales_price if it exists in the item', async () => {
-    const { result } = renderHookWithCioPlp(() =>
-      useProductInfo({ item: transformedItemWithSalePrice }),
-    );
-
-    await waitFor(() => {
-      const {
-        current: {
-          productSwatch,
-          itemName,
-          itemImageUrl,
-          itemUrl,
-          itemPrice,
-          itemId,
-          itemSalePrice,
-        },
-      } = result;
-
-      expect(productSwatch).not.toBeNull();
-      expect(itemId).toEqual(transformedItemWithSalePrice.itemId);
-      expect(itemName).toEqual(transformedItemWithSalePrice.itemName);
-      expect(itemImageUrl).toEqual(transformedItemWithSalePrice.imageUrl);
-      expect(itemUrl).toEqual(transformedItemWithSalePrice.url);
-      expect(itemPrice).toEqual(transformedItemWithSalePrice.data.price);
-      expect(itemSalePrice).toEqual(transformedItemWithSalePrice.data.salePrice);
-    });
-  });
-
-  it('Should return nothing properly with getters that return nothing', async () => {
-    const { result } = renderHookWithCioPlp(() => useProductInfo({ item: transformedItem }), {
-      initialProps: {
-        itemFieldGetters: {
-          getPrice: () => {},
-          getSwatches: () => {},
-          getSwatchPreview: () => {},
-          getSalePrice: () => {},
-        },
-      },
-    });
-
-    await waitFor(() => {
-      const {
-        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice },
-      } = result;
-
-      expect(productSwatch).not.toBeNull();
-      expect(itemName).toEqual(transformedItem.itemName);
-      expect(itemImageUrl).toEqual(transformedItem.imageUrl);
-      expect(itemUrl).toEqual(transformedItem.url);
-      expect(itemPrice).toBeUndefined();
+  describe.each([
+    {
+      item: transformedItem,
+      itemDescription: 'a standard item',
+    },
+    {
+      item: transformedItemWithSalePrice,
+      itemDescription: 'an item on sale',
+    },
+  ])('With $itemDescription', ({ item }) => {
+    it.each([
+      ['itemId', item.itemId],
+      ['itemName', item.itemName],
+      ['itemImageUrl', item.imageUrl],
+      ['itemUrl', item.url],
+      ['itemPrice', item.data.price],
+      ['salePrice', item.data.sale_price],
+    ])('Should return the correct value for "%s"', async (property, expectedValue) => {
+      const { result } = renderHookWithCioPlp(() => useProductInfo({ item }));
+      await waitFor(() => {
+        expect(result.current[property]).toEqual(expectedValue);
+      });
     });
   });
 

--- a/spec/hooks/useProductInfo/useProductInfo.test.js
+++ b/spec/hooks/useProductInfo/useProductInfo.test.js
@@ -3,6 +3,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import useProductInfo from '../../../src/hooks/useProduct';
 import { transformResultItem } from '../../../src/utils/transformers';
 import mockItem from '../../local_examples/item.json';
+import mockItemWithSalePrice from '../../local_examples/itemWithSalePrice.json';
 import { renderHookWithCioPlp } from '../../test-utils';
 
 describe('Testing Hook: useProductInfo', () => {
@@ -21,9 +22,29 @@ describe('Testing Hook: useProductInfo', () => {
   });
 
   const transformedItem = transformResultItem(mockItem);
+  const transformedItemWithSalePrice = transformResultItem(mockItemWithSalePrice);
 
   it('Should return productSwatch, itemId, itemName, itemImageUrl, itemUrl, itemPrice', async () => {
     const { result } = renderHookWithCioPlp(() => useProductInfo({ item: transformedItem }));
+
+    await waitFor(() => {
+      const {
+        current: { productSwatch, itemName, itemImageUrl, itemUrl, itemPrice, itemId },
+      } = result;
+
+      expect(productSwatch).not.toBeNull();
+      expect(itemId).toEqual(transformedItem.itemId);
+      expect(itemName).toEqual(transformedItem.itemName);
+      expect(itemImageUrl).toEqual(transformedItem.imageUrl);
+      expect(itemUrl).toEqual(transformedItem.url);
+      expect(itemPrice).toEqual(transformedItem.data.price);
+    });
+  });
+
+  it('Should return include a sales_price if it exists in the item', async () => {
+    const { result } = renderHookWithCioPlp(() =>
+      useProductInfo({ item: transformedItemWithSalePrice }),
+    );
 
     await waitFor(() => {
       const {

--- a/spec/hooks/useProductSwatch/useProductSwatch.test.js
+++ b/spec/hooks/useProductSwatch/useProductSwatch.test.js
@@ -4,7 +4,12 @@ import useProductSwatch from '../../../src/hooks/useProductSwatch';
 import { transformResultItem } from '../../../src/utils/transformers';
 import mockItem from '../../local_examples/item.json';
 import { renderHookWithCioPlp } from '../../test-utils';
-import { getSwatchPreview, getPrice, getSwatches } from '../../../src/utils/itemFieldGetters';
+import {
+  getSwatchPreview,
+  getPrice,
+  getSwatches,
+  getSalePrice,
+} from '../../../src/utils/itemFieldGetters';
 
 describe('Testing Hook: useProductSwatch', () => {
   beforeEach(() => {
@@ -18,7 +23,7 @@ describe('Testing Hook: useProductSwatch', () => {
   });
 
   const transformedItem = transformResultItem(mockItem);
-  const expectedSwatch = getSwatches(transformedItem, getPrice, getSwatchPreview);
+  const expectedSwatch = getSwatches(transformedItem, getPrice, getSwatchPreview, getSalePrice);
 
   it('Should throw error if called outside of PlpContext', () => {
     expect(() => renderHook(() => useProductSwatch())).toThrow();
@@ -63,6 +68,7 @@ describe('Testing Hook: useProductSwatch', () => {
           getPrice: () => {},
           getSwatches: () => {},
           getSwatchPreview: () => {},
+          getSalePrice: () => {},
         },
       },
     });
@@ -89,6 +95,9 @@ describe('Testing Hook: useProductSwatch', () => {
             throw new Error();
           },
           getSwatchPreview: () => {
+            throw new Error();
+          },
+          getSalePrice: () => {
             throw new Error();
           },
         },

--- a/spec/local_examples/itemWithSalePrice.json
+++ b/spec/local_examples/itemWithSalePrice.json
@@ -7,7 +7,7 @@
     "url": "https://constructorio-integrations.s3.amazonaws.com/tikus-threads/2022-06-29/KNIT-CASUAL-SHIRT_BUTTON-DOWN-KNIT-SHIRT_BKT00110SG1733_3_category.jpg",
     "price": 90,
     "altPrice": 69,
-    "sale_price": 23,
+    "sale_price": 21,
     "image_url": "https://constructorio-integrations.s3.amazonaws.com/tikus-threads/2022-06-29/KNIT-CASUAL-SHIRT_BUTTON-DOWN-KNIT-SHIRT_BKT00110SG1733_3_category.jpg",
     "group_ids": [
       "1111"

--- a/spec/local_examples/itemWithSalePrice.json
+++ b/spec/local_examples/itemWithSalePrice.json
@@ -7,6 +7,7 @@
     "url": "https://constructorio-integrations.s3.amazonaws.com/tikus-threads/2022-06-29/KNIT-CASUAL-SHIRT_BUTTON-DOWN-KNIT-SHIRT_BKT00110SG1733_3_category.jpg",
     "price": 90,
     "altPrice": 69,
+    "sale_price": 23,
     "image_url": "https://constructorio-integrations.s3.amazonaws.com/tikus-threads/2022-06-29/KNIT-CASUAL-SHIRT_BUTTON-DOWN-KNIT-SHIRT_BKT00110SG1733_3_category.jpg",
     "group_ids": [
       "1111"
@@ -31,6 +32,7 @@
         "variation_id": "BKT00110DG1733LR",
         "swatchPreview": "#e04062",
         "price": 90,
+        "sale_price": 21,
         "facets": [
           {
             "name": "Color",
@@ -47,6 +49,7 @@
         "variation_id": "BKT00110DG1733MR",
         "swatchPreview": "#a3c43b",
         "price": 99,
+        "sale_price": 22,
         "facets": [
           {
             "name": "Color",
@@ -63,6 +66,7 @@
         "variation_id": "BKT00110DG1733SR",
         "swatchPreview": "#253d37",
         "price": 100,
+        "sale_price": 23,
         "facets": [
           {
             "name": "Color",

--- a/src/components/ProductCard/ProductCard.css
+++ b/src/components/ProductCard/ProductCard.css
@@ -20,6 +20,19 @@
   width: 100%;
 }
 
+.cio-item-price.cio-item-price-sale {
+  text-decoration: line-through;
+  opacity: 0.7;
+  font-weight: 400;
+  font-size: 24px;
+}
+
+.cio-item-price-sale-container {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
 .cio-item-price {
   margin-top: 16px;
   font-weight: 700;

--- a/src/components/ProductCard/ProductCard.css
+++ b/src/components/ProductCard/ProductCard.css
@@ -20,7 +20,7 @@
   width: 100%;
 }
 
-.cio-item-price.cio-item-price-sale {
+.cio-item-price.cio-item-price-strikethrough {
   text-decoration: line-through;
   opacity: 0.7;
   font-weight: 400;

--- a/src/components/ProductCard/ProductCard.css
+++ b/src/components/ProductCard/ProductCard.css
@@ -27,7 +27,7 @@
   font-size: 24px;
 }
 
-.cio-item-price-sale-container {
+.cio-item-prices-container {
   display: flex;
   gap: 8px;
   align-items: center;

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -4,7 +4,7 @@ import { useOnAddToCart, useOnProductCardClick } from '../../hooks/callbacks';
 import { CnstrcData, IncludeRenderProps, Item, ProductInfoObject } from '../../types';
 import ProductSwatch from '../ProductSwatch';
 import useProductInfo from '../../hooks/useProduct';
-import { getProductCardCnstrcDataAttributes } from '../../utils';
+import { concatStyles, getProductCardCnstrcDataAttributes } from '../../utils';
 
 interface Props {
   /**
@@ -56,7 +56,7 @@ export default function ProductCard(props: ProductCardProps) {
   const { item, children } = props;
   const state = useCioPlpContext();
   const productInfo = useProductInfo({ item });
-  const { productSwatch, itemName, itemPrice, itemImageUrl, itemUrl } = productInfo;
+  const { productSwatch, itemName, itemPrice, itemImageUrl, itemUrl, salePrice } = productInfo;
 
   if (!state) {
     throw new Error('This component is meant to be used within the CioPlp provider.');
@@ -95,9 +95,20 @@ export default function ProductCard(props: ProductCardProps) {
           </div>
 
           <div className='cio-content'>
-            {Number(itemPrice) >= 0 && (
-              <div className='cio-item-price'>{formatPrice(itemPrice)}</div>
-            )}
+            <div className='cio-item-price-sale-container'>
+              {salePrice && Number(salePrice) >= 0 && (
+                <div className='cio-item-price'>{formatPrice(salePrice)}</div>
+              )}
+              {Number(itemPrice) >= 0 && (
+                <div
+                  className={concatStyles(
+                    'cio-item-price',
+                    Number(salePrice) >= 0 && 'cio-item-price-sale',
+                  )}>
+                  {formatPrice(itemPrice)}
+                </div>
+              )}
+            </div>
             <div className='cio-item-name'>{itemName}</div>
             {productSwatch && <ProductSwatch swatchObject={productSwatch} />}
           </div>

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -102,7 +102,7 @@ export default function ProductCard(props: ProductCardProps) {
                 <div
                   className={concatStyles(
                     'cio-item-price',
-                    hasSalesPrice && 'cio-item-price-sale',
+                    hasSalesPrice && 'cio-item-price-strikethrough',
                   )}>
                   {formatPrice(itemPrice)}
                 </div>

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useCioPlpContext } from '../../hooks/useCioPlpContext';
 import { useOnAddToCart, useOnProductCardClick } from '../../hooks/callbacks';
 import { CnstrcData, IncludeRenderProps, Item, ProductInfoObject } from '../../types';
@@ -70,6 +70,7 @@ export default function ProductCard(props: ProductCardProps) {
   const onAddToCart = useOnAddToCart(client, state.callbacks.onAddToCart);
   const { formatPrice } = state.formatters;
   const onClick = useOnProductCardClick(client, state.callbacks.onProductCardClick);
+  const hasSalesPrice = useMemo(() => !!(salePrice && Number(salePrice) >= 0), [salePrice]);
 
   const cnstrcData = getProductCardCnstrcDataAttributes(productInfo);
 
@@ -95,15 +96,13 @@ export default function ProductCard(props: ProductCardProps) {
           </div>
 
           <div className='cio-content'>
-            <div className='cio-item-price-sale-container'>
-              {salePrice && Number(salePrice) >= 0 && (
-                <div className='cio-item-price'>{formatPrice(salePrice)}</div>
-              )}
+            <div className='cio-item-prices-container'>
+              {hasSalesPrice && <div className='cio-item-price'>{formatPrice(salePrice)}</div>}
               {Number(itemPrice) >= 0 && (
                 <div
                   className={concatStyles(
                     'cio-item-price',
-                    Number(salePrice) >= 0 && 'cio-item-price-sale',
+                    hasSalesPrice && 'cio-item-price-sale',
                   )}>
                   {formatPrice(itemPrice)}
                 </div>

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -1,7 +1,11 @@
 import useProductSwatch from './useProductSwatch';
 import { useCioPlpContext } from './useCioPlpContext';
 import { UseProductInfo } from '../types';
-import { getSalePrice, tryCatchify } from '../utils';
+import { tryCatchify } from '../utils';
+import {
+  getPrice as defaultGetPrice,
+  getSalePrice as defaultGetSalePrice,
+} from '../utils/itemFieldGetters';
 
 const useProductInfo: UseProductInfo = ({ item }) => {
   const state = useCioPlpContext();
@@ -11,11 +15,12 @@ const useProductInfo: UseProductInfo = ({ item }) => {
     throw new Error('data, itemId, or itemName are required.');
   }
 
-  const getPrice = tryCatchify(state?.itemFieldGetters?.getPrice);
+  const getPrice = tryCatchify(state?.itemFieldGetters?.getPrice || defaultGetPrice);
+  const getSalePrice = tryCatchify(state?.itemFieldGetters?.getSalePrice || defaultGetSalePrice);
 
   const itemName = productSwatch?.selectedVariation?.itemName || item.itemName;
   const itemPrice = productSwatch?.selectedVariation?.price || getPrice(item);
-  const salePrice = productSwatch?.selectedVariation
+  const salePrice = productSwatch?.selectedVariation?.salePrice
     ? productSwatch?.selectedVariation?.salePrice
     : getSalePrice(item);
   const itemImageUrl = productSwatch?.selectedVariation?.imageUrl || item.imageUrl;

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -1,7 +1,7 @@
 import useProductSwatch from './useProductSwatch';
 import { useCioPlpContext } from './useCioPlpContext';
 import { UseProductInfo } from '../types';
-import { tryCatchify } from '../utils';
+import { getSalePrice, tryCatchify } from '../utils';
 
 const useProductInfo: UseProductInfo = ({ item }) => {
   const state = useCioPlpContext();
@@ -15,6 +15,9 @@ const useProductInfo: UseProductInfo = ({ item }) => {
 
   const itemName = productSwatch?.selectedVariation?.itemName || item.itemName;
   const itemPrice = productSwatch?.selectedVariation?.price || getPrice(item);
+  const salePrice = productSwatch?.selectedVariation
+    ? productSwatch?.selectedVariation?.salePrice
+    : getSalePrice(item);
   const itemImageUrl = productSwatch?.selectedVariation?.imageUrl || item.imageUrl;
   const itemUrl = productSwatch?.selectedVariation?.url || item.url;
   const variationId = productSwatch?.selectedVariation?.variationId;
@@ -28,6 +31,7 @@ const useProductInfo: UseProductInfo = ({ item }) => {
     itemUrl,
     variationId,
     itemId,
+    salePrice,
   };
 };
 

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -20,9 +20,7 @@ const useProductInfo: UseProductInfo = ({ item }) => {
 
   const itemName = productSwatch?.selectedVariation?.itemName || item.itemName;
   const itemPrice = productSwatch?.selectedVariation?.price || getPrice(item);
-  const salePrice = productSwatch?.selectedVariation?.salePrice
-    ? productSwatch?.selectedVariation?.salePrice
-    : getSalePrice(item);
+  const salePrice = productSwatch?.selectedVariation?.salePrice || getSalePrice(item);
   const itemImageUrl = productSwatch?.selectedVariation?.imageUrl || item.imageUrl;
   const itemUrl = productSwatch?.selectedVariation?.url || item.url;
   const variationId = productSwatch?.selectedVariation?.variationId;

--- a/src/hooks/useProductSwatch.ts
+++ b/src/hooks/useProductSwatch.ts
@@ -5,6 +5,7 @@ import {
   getSwatches as defaultGetSwatches,
   getPrice as defaultGetPrice,
   getSwatchPreview as defaultGetSwatchPreview,
+  getSalePrice as defaultGetSalePrice,
 } from '../utils/itemFieldGetters';
 
 const useProductSwatch: UseProductSwatch = ({ item }) => {
@@ -15,17 +16,18 @@ const useProductSwatch: UseProductSwatch = ({ item }) => {
 
   const getSwatches = state?.itemFieldGetters?.getSwatches || defaultGetSwatches;
   const getPrice = state?.itemFieldGetters?.getPrice || defaultGetPrice;
+  const getSalePrice = state?.itemFieldGetters?.getSalePrice || defaultGetSalePrice;
   const getSwatchPreview = state?.itemFieldGetters?.getSwatchPreview || defaultGetSwatchPreview;
 
   useEffect(() => {
     if (item?.variations) {
       try {
-        setSwatchList(getSwatches(item, getPrice, getSwatchPreview) || []);
+        setSwatchList(getSwatches(item, getPrice, getSwatchPreview, getSalePrice) || []);
       } catch (e) {
         // do nothing
       }
     }
-  }, [item, getSwatches, getPrice, getSwatchPreview]);
+  }, [item, getSwatches, getPrice, getSwatchPreview, getSalePrice]);
 
   useEffect(() => {
     if (item?.variations) {

--- a/src/stories/components/ProductCard/ProductCard.stories.ts
+++ b/src/stories/components/ProductCard/ProductCard.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { transformResultItem } from '../../../utils/transformers';
 import SampleItem from '../../../../spec/local_examples/item.json';
+import SampleItemWithSalePrice from '../../../../spec/local_examples/itemWithSalePrice.json';
 import ProductCardExample from './ProductCardExample';
 import '../../../styles.css';
 
@@ -25,5 +26,11 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     item: transformResultItem(SampleItem, false),
+  },
+};
+
+export const WithSalePrice: Story = {
+  args: {
+    item: transformResultItem(SampleItemWithSalePrice, false),
   },
 };

--- a/src/stories/components/ProductCard/RenderProps.md
+++ b/src/stories/components/ProductCard/RenderProps.md
@@ -8,10 +8,11 @@
 
 - `ProductInfo`:
 
-  | property      | type                                                                                                                  | description               |
-  | ------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-  | productSwatch | [ProductSwatch](../?path=/docs/components-productswatch--code-examples#arguments-passed-to-children-via-render-props) | Result ID of the response |
-  | itemName      | `string`                                                                                                              | Name of item              |
-  | itemPrice     | `number`                                                                                                              | Price of item             |
-  | itemImageUrl  | `string`                                                                                                              | URL of item image         |
-  | itemUrl       | `string`                                                                                                              | URL to item PDP           |
+  | property      | type                                                                                                                  | description                 |
+  | ------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+  | productSwatch | [ProductSwatch](../?path=/docs/components-productswatch--code-examples#arguments-passed-to-children-via-render-props) | Result ID of the response   |
+  | itemName      | `string`                                                                                                              | Name of item                |
+  | itemPrice     | `number`                                                                                                              | Price of item               |
+  | salePrice     | `number`                                                                                                              | Price of item with discount |
+  | itemImageUrl  | `string`                                                                                                              | URL of item image           |
+  | itemUrl       | `string`                                                                                                              | URL to item PDP             |

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,11 +40,13 @@ export type CioClientOptions = Omit<ConstructorClientOptions, 'apiKey' | 'sendTr
 
 export interface ItemFieldGetters {
   getPrice: (item: Item | Variation) => number;
+  getSalePrice: (item: Item | Variation) => number;
   getSwatchPreview: (variation: Variation) => string;
   getSwatches: (
     item: Item,
     retrievePrice: ItemFieldGetters['getPrice'],
     retrieveSwatchPreview: ItemFieldGetters['getSwatchPreview'],
+    retrieveSalePrice: ItemFieldGetters['getSalePrice'],
   ) => SwatchItem[] | undefined;
 }
 
@@ -195,6 +197,7 @@ export interface SwatchItem {
   itemName?: string;
   imageUrl?: string;
   price?: number;
+  salePrice?: number;
   swatchPreview: string;
   variationId?: string;
 }
@@ -244,6 +247,7 @@ export interface ProductInfoObject {
   itemName: string;
   itemId: string;
   itemPrice?: number;
+  salePrice?: number;
   itemUrl?: string;
   itemImageUrl?: string;
   variationId?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export type CioClientOptions = Omit<ConstructorClientOptions, 'apiKey' | 'sendTr
 
 export interface ItemFieldGetters {
   getPrice: (item: Item | Variation) => number;
-  getSalePrice: (item: Item | Variation) => number;
+  getSalePrice: (item: Item | Variation) => number | undefined;
   getSwatchPreview: (variation: Variation) => string;
   getSwatches: (
     item: Item,

--- a/src/utils/itemFieldGetters.ts
+++ b/src/utils/itemFieldGetters.ts
@@ -5,10 +5,15 @@ export function getPrice(item: Item | Variation): number {
   return item.data.price;
 }
 
+export function getSalePrice(item: Item | Variation): number | undefined {
+  return item.data.sale_price;
+}
+
 export function getSwatches(
   item: Item,
   retrievePrice: ItemFieldGetters['getPrice'],
   retrieveSwatchPreview: ItemFieldGetters['getSwatchPreview'],
+  retrieveSalePrice: ItemFieldGetters['getSalePrice'],
 ): SwatchItem[] | undefined {
   const swatchList: SwatchItem[] = [];
 
@@ -20,6 +25,7 @@ export function getSwatches(
         imageUrl: variation?.url,
         variationId: variation?.variationId,
         price: retrievePrice(variation),
+        salePrice: retrieveSalePrice(variation),
         swatchPreview: retrieveSwatchPreview(variation),
       });
     }


### PR DESCRIPTION
- Add logic to handle `sale_price`
- Add product card styling for sale price
- Add custom `itemFieldGetter` to define where to get sale price from
- Add storybook example and test cases

<img width="618" height="928" alt="image" src="https://github.com/user-attachments/assets/bcb297b3-3e70-4614-b8c4-29d9a7da1dcb" />
