### PR TITLE
[CI-4670]- Add data-cnstrc-result-id data attribute to the results container

### DIFF
--- a/spec/components/CioPlpGrid/CioPlpGrid.server.test.jsx
+++ b/spec/components/CioPlpGrid/CioPlpGrid.server.test.jsx
@@ -86,7 +86,7 @@ describe('Testing Component on the server: CioPlpGrid', () => {
     );
 
     expect(html).toContain('data-cnstrc-search');
-    expect(html).toContain('data-cnstrc-num-results="357"');
-    expect(html).toContain('data-cnstrc-result-id="c7000c32-0399-4bae-8e23-fb67bd0ecb62"');
+    expect(html).toContain(`data-cnstrc-num-results="${mockSearchData.response.totalNumResults}"`);
+    expect(html).toContain(`data-cnstrc-result-id="${mockSearchData.resultId}"`);
   });
 });

--- a/spec/components/CioPlpGrid/CioPlpGrid.server.test.jsx
+++ b/spec/components/CioPlpGrid/CioPlpGrid.server.test.jsx
@@ -87,5 +87,6 @@ describe('Testing Component on the server: CioPlpGrid', () => {
 
     expect(html).toContain('data-cnstrc-search');
     expect(html).toContain('data-cnstrc-num-results="357"');
+    expect(html).toContain('data-cnstrc-result-id="c7000c32-0399-4bae-8e23-fb67bd0ecb62"');
   });
 });

--- a/spec/components/CioPlpGrid/CioPlpGrid.test.jsx
+++ b/spec/components/CioPlpGrid/CioPlpGrid.test.jsx
@@ -251,11 +251,13 @@ describe('Testing Component: CioPlpGrid', () => {
       const totalNumResults = getAttributeFromContainer('data-cnstrc-num-results');
       const filterName = getAttributeFromContainer('data-cnstrc-filter-name');
       const filterValue = getAttributeFromContainer('data-cnstrc-filter-value');
+      const resultId = getAttributeFromContainer('data-cnstrc-result-id');
 
       expect(container.querySelector('[data-cnstrc-browse]')).toBeInTheDocument();
       expect(totalNumResults).toEqual(String(mockBrowseData.response.totalNumResults));
       expect(filterName).toEqual(String(mockBrowseData.request.browse_filter_name));
       expect(filterValue).toEqual(String(mockBrowseData.request.browse_filter_value));
+      expect(resultId).toEqual(String(mockBrowseData.resultId));
     });
   });
 
@@ -308,6 +310,9 @@ describe('Testing Component: CioPlpGrid', () => {
           .querySelector('[data-cnstrc-num-results]')
           .getAttribute('data-cnstrc-num-results'),
       ).toEqual(String(mockSearchData.response.totalNumResults));
+      expect(
+        container.querySelector('[data-cnstrc-result-id]').getAttribute('data-cnstrc-result-id'),
+      ).toEqual(String(mockSearchData.resultId));
     });
   });
 
@@ -331,6 +336,9 @@ describe('Testing Component: CioPlpGrid', () => {
           .querySelector('[data-cnstrc-num-results]')
           .getAttribute('data-cnstrc-num-results'),
       ).toEqual('0');
+      expect(
+        container.querySelector('[data-cnstrc-result-id]').getAttribute('data-cnstrc-result-id'),
+      ).toEqual('test-zero-results');
     });
   });
 });

--- a/src/utils/dataAttributeHelpers.ts
+++ b/src/utils/dataAttributeHelpers.ts
@@ -39,6 +39,7 @@ export function getPlpContainerCnstrcDataAttributes(
       dataCnstrc = {
         'data-cnstrc-browse': true,
         'data-cnstrc-num-results': data.response.totalNumResults,
+        'data-cnstrc-result-id': data.resultId,
         'data-cnstrc-filter-name': filterName!,
         'data-cnstrc-filter-value': filterValue!,
       };
@@ -47,6 +48,7 @@ export function getPlpContainerCnstrcDataAttributes(
     case 'search':
       dataCnstrc = {
         'data-cnstrc-search': true,
+        'data-cnstrc-result-id': data.resultId,
         'data-cnstrc-num-results': data.response.totalNumResults,
       };
       break;


### PR DESCRIPTION
- Added `data-cnstrc-result-id` data attribute for search and browser container so we can track the result ID for customers who are using the PLP UI library

# Pull Request Checklist

Before you submit a pull request, please make sure you have to following:

- [ ] I have added or updated TypeScript types for my changes, ensuring they are compatible with the existing codebase.
- [ ] I have added JSDoc comments to my TypeScript definitions for improved documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added any necessary documentation (if appropriate).
- [x] I have made sure my PR is up-to-date with the main branch.

# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] TypeScript type definitions update
- [x] Other... Please describe:
Added data-cnstrc-result-id data attribute for search and browser container so we can track the result ID for customers who are using the PLP UI library
