### PR TITLE
[CDX-191] Expose sliderStep prop for FilterRangeSlider and add facet-specific slider steps

### DIFF
--- a/spec/hooks/useFilter/useFilter.test.js
+++ b/spec/hooks/useFilter/useFilter.test.js
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { renderHook, waitFor } from '@testing-library/react';
 import useFilter from '../../../src/hooks/useFilter';
 import mockSearchResponse from '../../local_examples/apiSearchResponse.json';
-import { transformSearchResponse } from '../../../src/utils/transformers';
+import { transformSearchResponse } from '../../../src/utils';
 import { renderHookWithCioPlp } from '../../test-utils';
 
 describe('Testing Hook: useFilter', () => {
@@ -139,6 +139,37 @@ describe('Testing Hook: useFilter', () => {
 
       expect(window.location.href.indexOf(testBrandA)).toBe(-1);
       expect(window.location.href.indexOf('Brand')).toBe(-1);
+    });
+  });
+
+  it('Should return sliderStep when provided', async () => {
+    const useFilterPropsWithSliderStep = {
+      ...useFilterProps,
+      sliderStep: 0.5,
+    };
+    const { result } = renderHookWithCioPlp(() => useFilter(useFilterPropsWithSliderStep));
+
+    await waitFor(() => {
+      const {
+        current: { sliderStep },
+      } = result;
+      expect(sliderStep).toBe(0.5);
+    });
+  });
+
+  it('Should return facetSliderSteps when provided', async () => {
+    const facetSliderSteps = { price: 1, rating: 0.1 };
+    const useFilterPropsWithFacetSliderSteps = {
+      ...useFilterProps,
+      facetSliderSteps,
+    };
+    const { result } = renderHookWithCioPlp(() => useFilter(useFilterPropsWithFacetSliderSteps));
+
+    await waitFor(() => {
+      const {
+        current: { facetSliderSteps: returnedFacetSliderSteps },
+      } = result;
+      expect(returnedFacetSliderSteps).toEqual(facetSliderSteps);
     });
   });
 });

--- a/src/components/Filters/FilterGroup.tsx
+++ b/src/components/Filters/FilterGroup.tsx
@@ -9,10 +9,12 @@ export interface FilterGroupProps {
   facet: PlpFacet;
   setFilter: UseFilterReturn['setFilter'];
   initialNumOptions?: number;
+  sliderStep?: number;
+  facetSliderSteps?: Record<string, number>;
 }
 
 export default function FilterGroup(props: FilterGroupProps) {
-  const { facet, setFilter, initialNumOptions = 10 } = props;
+  const { facet, setFilter, initialNumOptions = 10, sliderStep, facetSliderSteps } = props;
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const toggleIsCollapsed = () => setIsCollapsed(!isCollapsed);
@@ -41,6 +43,7 @@ export default function FilterGroup(props: FilterGroupProps) {
           isCollapsed={isCollapsed}
           rangedFacet={facet}
           modifyRequestRangeFilter={onFilterSelect(facet.name)}
+          sliderStep={facetSliderSteps?.[facet.name] || sliderStep}
         />
       )}
     </li>

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -15,7 +15,7 @@ export type FiltersWithRenderProps = IncludeRenderProps<FiltersProps, UseFilterR
 
 export default function Filters(props: FiltersWithRenderProps) {
   const { children, initialNumOptions, ...useFiltersProps } = props;
-  const { facets, setFilter } = useFilter(useFiltersProps);
+  const { facets, setFilter, sliderStep, facetSliderSteps } = useFilter(useFiltersProps);
 
   return (
     <>
@@ -23,6 +23,8 @@ export default function Filters(props: FiltersWithRenderProps) {
         children({
           facets,
           setFilter,
+          sliderStep,
+          facetSliderSteps,
         })
       ) : (
         <div className='cio-filters'>
@@ -31,6 +33,8 @@ export default function Filters(props: FiltersWithRenderProps) {
               facet={facet}
               initialNumOptions={initialNumOptions}
               setFilter={setFilter}
+              sliderStep={sliderStep}
+              facetSliderSteps={facetSliderSteps}
               key={facet.name}
             />
           ))}

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -5,6 +5,8 @@ import useRequestConfigs from './useRequestConfigs';
 export interface UseFilterReturn {
   facets: Array<PlpFacet>;
   setFilter: (filterName: string, filterValue: PlpFilterValue) => void;
+  sliderStep?: number;
+  facetSliderSteps?: Record<string, number>;
 }
 
 export interface UseFilterProps {
@@ -12,10 +14,18 @@ export interface UseFilterProps {
    * Used to build and render filters dynamically
    */
   facets: Array<PlpFacet>;
+  /**
+   * Global slider step for all range facets
+   */
+  sliderStep?: number;
+  /**
+   * Per-facet slider step configuration
+   */
+  facetSliderSteps?: Record<string, number>;
 }
 
 export default function useFilter(props: UseFilterProps): UseFilterReturn {
-  const { facets } = props;
+  const { facets, sliderStep, facetSliderSteps } = props;
   const contextValue = useCioPlpContext();
 
   if (!contextValue) {
@@ -40,5 +50,7 @@ export default function useFilter(props: UseFilterProps): UseFilterReturn {
   return {
     facets,
     setFilter,
+    sliderStep,
+    facetSliderSteps,
   };
 }


### PR DESCRIPTION
This pull request adds support for configuring the step size of range sliders in the `Filters` component, both globally and per-facet. It also updates related tests and hooks to ensure that the new `sliderStep` and `facetSliderSteps` props are handled and tested correctly.

**Slider Step Configuration Support:**

* Added `sliderStep` (global) and `facetSliderSteps` (per-facet) props to `Filters`, `FilterGroup`, and `useFilter` to control the step size for range sliders. The per-facet value takes precedence over the global one. 

**Testing Enhancements:**

* Added and updated tests in `Filters.test.jsx` to verify correct application of `sliderStep` and `facetSliderSteps`, including edge cases and user interactions. 
* Added tests to `useFilter.test.js` to confirm that the hook returns the correct `sliderStep` and `facetSliderSteps` values when provided.

**Test Cleanups:**

* Removed a stray `.only` from a test case to ensure all tests are run.


<details>
  <summary>Video preview inside</summary>

https://github.com/user-attachments/assets/4c74a322-c704-4b1d-81d1-457b713c7513

</details>