### PR TITLE
Bugfix: update FilterRangeSlider on facet min/max change

### DIFF
--- a/spec/components/Filters/FilterGroup.test.jsx
+++ b/spec/components/Filters/FilterGroup.test.jsx
@@ -646,7 +646,7 @@ describe('Testing Component: FilterGroup', () => {
       expect(sliders[1]).toHaveAttribute('min', '10');
       expect(sliders[1]).toHaveAttribute('max', '90');
 
-      // Input fields should show the single facet value
+      // Input fields should also come from status (10-90), not facet (50-50)
       expect(numberInputs[0]).toHaveValue(10);
       expect(numberInputs[1]).toHaveValue(90);
     });
@@ -666,7 +666,7 @@ describe('Testing Component: FilterGroup', () => {
       const { rerender } = renderFilterGroup(initialFacet);
 
       const numberInputs = screen.getAllByRole('spinbutton');
-      const sliders = screen.getAllByRole('slider');
+      let sliders = screen.getAllByRole('slider');
 
       expect(numberInputs[0]).not.toBeDisabled();
       expect(numberInputs[1]).not.toBeDisabled();
@@ -682,13 +682,20 @@ describe('Testing Component: FilterGroup', () => {
         />,
       );
 
+      sliders = screen.getAllByRole('slider');
+
       // Should become disabled
       expect(numberInputs[0]).toBeDisabled();
       expect(numberInputs[1]).toBeDisabled();
       expect(sliders[0]).toBeDisabled();
       expect(sliders[1]).toBeDisabled();
 
-      // Input fields should show the single facet value
+      // Display range should come from status (30-70), not facet (50-50)
+      expect(sliders[0]).toHaveAttribute('min', '30');
+      expect(sliders[0]).toHaveAttribute('max', '70');
+      expect(sliders[1]).toHaveAttribute('min', '30');
+      expect(sliders[1]).toHaveAttribute('max', '70');
+      // Input fields should come from status (30-70), not facet (50-50)
       expect(numberInputs[0]).toHaveValue(30);
       expect(numberInputs[1]).toHaveValue(70);
     });

--- a/spec/components/Filters/FilterGroup.test.jsx
+++ b/spec/components/Filters/FilterGroup.test.jsx
@@ -588,7 +588,7 @@ describe('Testing Component: FilterGroup', () => {
 
         const sliders = screen.getAllByRole('slider');
 
-        // Values (30, 60) are still within the new range, so they should stay
+        // Values should widen to match the new facet bounds
         expect(numberInputs[0]).toHaveValue(10);
         expect(numberInputs[1]).toHaveValue(90);
         expect(sliders[0]).toHaveValue('10');

--- a/spec/components/Filters/FilterGroup.test.jsx
+++ b/spec/components/Filters/FilterGroup.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import FilterGroup from '../../../src/components/Filters/FilterGroup';
 
@@ -87,5 +87,393 @@ describe('Testing Component: FilterGroup', () => {
 
     // setFilter should not be called on initial render
     expect(mockSetFilter).not.toHaveBeenCalled();
+  });
+
+  describe('Range Slider Clamping', () => {
+    const renderFilterGroup = (facet) =>
+      render(<FilterGroup facet={facet} setFilter={mockSetFilter} initialNumOptions={10} />);
+
+    describe('when facet has status', () => {
+      it('Should clamp status values to facet min/max on initial render', () => {
+        renderFilterGroup({
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 10,
+          max: 90,
+          status: { min: 5, max: 100 },
+        });
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+        const sliders = screen.getAllByRole('slider');
+
+        // Status values (5, 100) should be clamped to facet range (10, 90)
+        expect(numberInputs[0]).toHaveValue(10);
+        expect(numberInputs[1]).toHaveValue(90);
+        expect(sliders[0]).toHaveValue('10');
+        expect(sliders[1]).toHaveValue('90');
+      });
+
+      it('Should clamp slider and input values when facet min/max narrows', () => {
+        const initialFacet = {
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 0,
+          max: 100,
+          status: { min: 20, max: 80 },
+        };
+
+        const { rerender } = renderFilterGroup(initialFacet);
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+        expect(numberInputs[0]).toHaveValue(20);
+        expect(numberInputs[1]).toHaveValue(80);
+
+        // Simulate another filter narrowing the facet range to 30-70
+        rerender(
+          <FilterGroup
+            facet={{ ...initialFacet, min: 30, max: 70, status: { min: 20, max: 80 } }}
+            setFilter={mockSetFilter}
+            initialNumOptions={10}
+          />,
+        );
+
+        const sliders = screen.getAllByRole('slider');
+
+        // Values (20, 80) should be clamped to new range (30, 70)
+        expect(numberInputs[0]).toHaveValue(30);
+        expect(numberInputs[1]).toHaveValue(70);
+        expect(sliders[0]).toHaveValue('30');
+        expect(sliders[1]).toHaveValue('70');
+      });
+
+      it('Should keep slider and input values when facet min/max widens', () => {
+        const initialFacet = {
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 20,
+          max: 80,
+          status: { min: 30, max: 60 },
+        };
+
+        const { rerender } = renderFilterGroup(initialFacet);
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+        expect(numberInputs[0]).toHaveValue(30);
+        expect(numberInputs[1]).toHaveValue(60);
+
+        // Facet range widens to 0-100
+        rerender(
+          <FilterGroup
+            facet={{ ...initialFacet, min: 0, max: 100, status: { min: 30, max: 60 } }}
+            setFilter={mockSetFilter}
+            initialNumOptions={10}
+          />,
+        );
+
+        const sliders = screen.getAllByRole('slider');
+
+        // Values (30, 60) are still within the new range, so they should stay
+        expect(numberInputs[0]).toHaveValue(30);
+        expect(numberInputs[1]).toHaveValue(60);
+        expect(sliders[0]).toHaveValue('30');
+        expect(sliders[1]).toHaveValue('60');
+      });
+
+      it('Should partially clamp when only one bound exceeds the new range', () => {
+        const initialFacet = {
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 0,
+          max: 100,
+          status: { min: 20, max: 80 },
+        };
+
+        const { rerender } = renderFilterGroup(initialFacet);
+
+        // Facet range narrows on the max side only
+        rerender(
+          <FilterGroup
+            facet={{ ...initialFacet, min: 0, max: 50, status: { min: 20, max: 80 } }}
+            setFilter={mockSetFilter}
+            initialNumOptions={10}
+          />,
+        );
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+        const sliders = screen.getAllByRole('slider');
+
+        // Min (20) is still within range, max (80) should clamp to 50
+        expect(numberInputs[0]).toHaveValue(20);
+        expect(numberInputs[1]).toHaveValue(50);
+        expect(sliders[0]).toHaveValue('20');
+        expect(sliders[1]).toHaveValue('50');
+      });
+    });
+
+    describe('When facet does not have status', () => {
+      it('Should clamp slider and input values when facet min/max narrows for facet without status', () => {
+        const initialFacet = {
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 0,
+          max: 100,
+          status: {},
+        };
+
+        const { rerender } = renderFilterGroup(initialFacet);
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+        const sliders = screen.getAllByRole('slider');
+
+        expect(numberInputs[0]).toHaveValue(0);
+        expect(numberInputs[1]).toHaveValue(100);
+        expect(sliders[0]).toHaveValue('0');
+        expect(sliders[1]).toHaveValue('100');
+
+        // Simulate another filter narrowing the facet range to 30-70
+        rerender(
+          <FilterGroup
+            facet={{ ...initialFacet, min: 30, max: 70, status: {} }}
+            setFilter={mockSetFilter}
+            initialNumOptions={10}
+          />,
+        );
+
+        // Values (0, 100) should be clamped to new range (30, 70)
+        expect(numberInputs[0]).toHaveValue(30);
+        expect(numberInputs[1]).toHaveValue(70);
+        expect(sliders[0]).toHaveValue('30');
+        expect(sliders[1]).toHaveValue('70');
+      });
+
+      it('Should clamp user-selected values when facet range narrows after slider interaction', () => {
+        const initialFacet = {
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 0,
+          max: 100,
+          status: {},
+        };
+
+        const { rerender } = renderFilterGroup(initialFacet);
+
+        const sliders = screen.getAllByRole('slider');
+
+        // User drags sliders to 10-90
+        fireEvent.change(sliders[0], { target: { value: 10 } });
+        fireEvent.mouseUp(sliders[0]);
+        fireEvent.change(sliders[1], { target: { value: 90 } });
+        fireEvent.mouseUp(sliders[1]);
+
+        // Facet range narrows to 25-75
+        rerender(
+          <FilterGroup
+            facet={{ ...initialFacet, min: 25, max: 75, status: { min: 10, max: 90 } }}
+            setFilter={mockSetFilter}
+            initialNumOptions={10}
+          />,
+        );
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+
+        // User's selection (10, 90) should be clamped to new range (25, 75)
+        expect(numberInputs[0]).toHaveValue(25);
+        expect(numberInputs[1]).toHaveValue(75);
+        expect(sliders[0]).toHaveValue('25');
+        expect(sliders[1]).toHaveValue('75');
+      });
+
+      it('Should widen slider and input values when facet min/max widens', () => {
+        const initialFacet = {
+          displayName: 'Price',
+          name: 'price',
+          type: 'range',
+          data: {},
+          hidden: false,
+          min: 20,
+          max: 80,
+          status: {},
+        };
+
+        const { rerender } = renderFilterGroup(initialFacet);
+
+        const numberInputs = screen.getAllByRole('spinbutton');
+        expect(numberInputs[0]).toHaveValue(20);
+        expect(numberInputs[1]).toHaveValue(80);
+
+        // Facet range widens to 0-100
+        rerender(
+          <FilterGroup
+            facet={{ ...initialFacet, min: 10, max: 90, status: {} }}
+            setFilter={mockSetFilter}
+            initialNumOptions={10}
+          />,
+        );
+
+        const sliders = screen.getAllByRole('slider');
+
+        // Values (30, 60) are still within the new range, so they should stay
+        expect(numberInputs[0]).toHaveValue(10);
+        expect(numberInputs[1]).toHaveValue(90);
+        expect(sliders[0]).toHaveValue('10');
+        expect(sliders[1]).toHaveValue('90');
+      });
+    });
+  });
+
+  describe('Single Value Facets (min === max)', () => {
+    const renderFilterGroup = (facet) =>
+      render(<FilterGroup facet={facet} setFilter={mockSetFilter} initialNumOptions={10} />);
+
+    it('Should disable sliders and inputs when facet has a single value', () => {
+      renderFilterGroup({
+        displayName: 'Price',
+        name: 'price',
+        type: 'range',
+        data: {},
+        hidden: false,
+        min: 50,
+        max: 50,
+        status: {},
+      });
+
+      const numberInputs = screen.getAllByRole('spinbutton');
+      const sliders = screen.getAllByRole('slider');
+
+      expect(numberInputs[0]).toBeDisabled();
+      expect(numberInputs[1]).toBeDisabled();
+      expect(sliders[0]).toBeDisabled();
+      expect(sliders[1]).toBeDisabled();
+
+      expect(numberInputs[0]).toHaveValue(50);
+      expect(numberInputs[1]).toHaveValue(50);
+    });
+
+    it('Should use status for display range when facet is single value with status', () => {
+      renderFilterGroup({
+        displayName: 'Price',
+        name: 'price',
+        type: 'range',
+        data: {},
+        hidden: false,
+        min: 50,
+        max: 50,
+        status: { min: 10, max: 90 },
+      });
+
+      const sliders = screen.getAllByRole('slider');
+      const numberInputs = screen.getAllByRole('spinbutton');
+
+      // Display range should come from status (10-90), not facet (50-50)
+      expect(sliders[0]).toHaveAttribute('min', '10');
+      expect(sliders[0]).toHaveAttribute('max', '90');
+      expect(sliders[1]).toHaveAttribute('min', '10');
+      expect(sliders[1]).toHaveAttribute('max', '90');
+
+      // Input fields should show the single facet value
+      expect(numberInputs[0]).toHaveValue(10);
+      expect(numberInputs[1]).toHaveValue(90);
+    });
+
+    it('Should transition from multi-value to single-value when facet range collapses', () => {
+      const initialFacet = {
+        displayName: 'Price',
+        name: 'price',
+        type: 'range',
+        data: {},
+        hidden: false,
+        min: 10,
+        max: 100,
+        status: { min: 30, max: 70 },
+      };
+
+      const { rerender } = renderFilterGroup(initialFacet);
+
+      const numberInputs = screen.getAllByRole('spinbutton');
+      const sliders = screen.getAllByRole('slider');
+
+      expect(numberInputs[0]).not.toBeDisabled();
+      expect(numberInputs[1]).not.toBeDisabled();
+      expect(sliders[0]).not.toBeDisabled();
+      expect(sliders[1]).not.toBeDisabled();
+
+      // Facet collapses to a single value, status retains previous selection
+      rerender(
+        <FilterGroup
+          facet={{ ...initialFacet, min: 50, max: 50, status: { min: 30, max: 70 } }}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+        />,
+      );
+
+      // Should become disabled
+      expect(numberInputs[0]).toBeDisabled();
+      expect(numberInputs[1]).toBeDisabled();
+      expect(sliders[0]).toBeDisabled();
+      expect(sliders[1]).toBeDisabled();
+
+      // Input fields should show the single facet value
+      expect(numberInputs[0]).toHaveValue(30);
+      expect(numberInputs[1]).toHaveValue(70);
+    });
+
+    it('Should transition from single-value to multi-value when facet range expands', () => {
+      const initialFacet = {
+        displayName: 'Price',
+        name: 'price',
+        type: 'range',
+        data: {},
+        hidden: false,
+        min: 50,
+        max: 50,
+        status: { min: 10, max: 90 },
+      };
+
+      const { rerender } = renderFilterGroup(initialFacet);
+
+      const numberInputs = screen.getAllByRole('spinbutton');
+      const sliders = screen.getAllByRole('slider');
+
+      expect(numberInputs[0]).toBeDisabled();
+
+      // Facet expands back to a range
+      rerender(
+        <FilterGroup
+          facet={{ ...initialFacet, min: 0, max: 100, status: { min: 10, max: 90 } }}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+        />,
+      );
+
+      // Should become enabled
+      expect(numberInputs[0]).not.toBeDisabled();
+      expect(numberInputs[1]).not.toBeDisabled();
+      expect(sliders[0]).not.toBeDisabled();
+      expect(sliders[1]).not.toBeDisabled();
+
+      // Status values should be clamped to new range
+      expect(numberInputs[0]).toHaveValue(10);
+      expect(numberInputs[1]).toHaveValue(90);
+      expect(sliders[0]).toHaveValue('10');
+      expect(sliders[1]).toHaveValue('90');
+    });
   });
 });

--- a/spec/components/Filters/Filters.test.jsx
+++ b/spec/components/Filters/Filters.test.jsx
@@ -231,8 +231,8 @@ describe('Testing Component: Filters', () => {
         const minInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-min-slider');
         const maxInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-max-slider');
 
-        expect(selectableTrack.style.width).toBe('100%');
-        expect(selectableTrack.style.left).toBe('0%');
+        expect(selectableTrack.style.width).toBe('100.00%');
+        expect(selectableTrack.style.left).toBe('0.00%');
 
         expect(minInputSlider.min).toBe(mockPriceFacet.min.toString());
         expect(minInputSlider.max).toBe(mockPriceFacet.max.toString());
@@ -329,8 +329,8 @@ describe('Testing Component: Filters', () => {
         const minInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-min-slider');
         const maxInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-max-slider');
 
-        expect(selectableTrack.style.width).toBe('75%');
-        expect(selectableTrack.style.left).toBe('0%');
+        expect(selectableTrack.style.width).toBe('75.00%');
+        expect(selectableTrack.style.left).toBe('0.00%');
 
         expect(minInputSlider.min).toBe(mockPriceFacet.min.toString());
         expect(minInputSlider.max).toBe(mockPriceFacet.max.toString());

--- a/spec/components/Filters/Filters.test.jsx
+++ b/spec/components/Filters/Filters.test.jsx
@@ -850,7 +850,6 @@ describe('Testing Component: Filters', () => {
       expect(smallCheckbox).not.toBeChecked();
     });
   });
-
   describe(' - Facet Blacklisting Tests', () => {
     it('Should not render facets when isHiddenFilterFn returns true', async () => {
       const isHiddenFilterFn = (facet) => facet.name === 'color'; // lowercase 'color'
@@ -899,7 +898,11 @@ describe('Testing Component: Filters', () => {
 
       const { container } = render(
         <CioPlp apiKey={DEMO_API_KEY}>
-          <Filters facets={[colorFacet]} isHiddenFilterOptionFn={isHiddenFilterOptionFn} initialNumOptions={100} />
+          <Filters
+            facets={[colorFacet]}
+            isHiddenFilterOptionFn={isHiddenFilterOptionFn}
+            initialNumOptions={100}
+          />
         </CioPlp>,
       );
 

--- a/spec/components/Filters/Filters.test.jsx
+++ b/spec/components/Filters/Filters.test.jsx
@@ -231,8 +231,8 @@ describe('Testing Component: Filters', () => {
         const minInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-min-slider');
         const maxInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-max-slider');
 
-        expect(selectableTrack.style.width).toBe('100.00%');
-        expect(selectableTrack.style.left).toBe('0.00%');
+        expect(selectableTrack.style.width).toBe('100%');
+        expect(selectableTrack.style.left).toBe('0%');
 
         expect(minInputSlider.min).toBe(mockPriceFacet.min.toString());
         expect(minInputSlider.max).toBe(mockPriceFacet.max.toString());
@@ -329,8 +329,8 @@ describe('Testing Component: Filters', () => {
         const minInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-min-slider');
         const maxInputSlider = container.querySelector('.cio-doubly-ended-slider .cio-max-slider');
 
-        expect(selectableTrack.style.width).toBe('75.00%');
-        expect(selectableTrack.style.left).toBe('0.00%');
+        expect(selectableTrack.style.width).toBe('75%');
+        expect(selectableTrack.style.left).toBe('0%');
 
         expect(minInputSlider.min).toBe(mockPriceFacet.min.toString());
         expect(minInputSlider.max).toBe(mockPriceFacet.max.toString());

--- a/src/components/Filters/FilterRangeSlider.tsx
+++ b/src/components/Filters/FilterRangeSlider.tsx
@@ -41,10 +41,6 @@ function getDisplayRange(facet: PlpRangeFacet, isSingleValue: boolean) {
   };
 }
 
-function getClampedValue(value: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, value));
-}
-
 // Default track styles when range collapses to a single value
 const COLLAPSED_TRACK_STYLE = { left: '0%', width: '100%' };
 

--- a/src/components/Filters/FilterRangeSlider.tsx
+++ b/src/components/Filters/FilterRangeSlider.tsx
@@ -41,6 +41,10 @@ function getDisplayRange(facet: PlpRangeFacet, isSingleValue: boolean) {
   };
 }
 
+function getClampedValue(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
 // Default track styles when range collapses to a single value
 const COLLAPSED_TRACK_STYLE = { left: '0%', width: '100%' };
 
@@ -144,16 +148,17 @@ export default function FilterRangeSlider(props: FilterRangeSliderProps) {
     }
   };
 
-  // Update internal state when facet changes
+  // Update internal state when facet status changes
   useEffect(() => {
     if (facet.status?.min !== undefined) {
       const clampedMin = Math.max(displayMin, Math.min(displayMax, facet.status.min));
-      const clampedMax = Math.max(displayMin, Math.min(displayMax, facet.status.max));
-
       setMinValue(clampedMin);
-      setMaxValue(clampedMax);
-
       setInputMinValue(isSingleValue ? facet.status.min : clampedMin);
+    }
+
+    if (facet.status?.max !== undefined) {
+      const clampedMax = Math.max(displayMin, Math.min(displayMax, facet.status.max));
+      setMaxValue(clampedMax);
       setInputMaxValue(isSingleValue ? facet.status.max : clampedMax);
     }
   }, [
@@ -165,6 +170,18 @@ export default function FilterRangeSlider(props: FilterRangeSliderProps) {
     displayMax,
     isSingleValue,
   ]);
+
+  // Update internal state when facet's min/max change (e.g. due to another filter being applied)
+  useEffect(() => {
+    if (facet.status?.min === undefined) {
+      setMinValue(displayMin);
+      setInputMinValue(displayMin);
+    }
+    if (facet.status?.max === undefined) {
+      setMaxValue(displayMax);
+      setInputMaxValue(displayMax);
+    }
+  }, [displayMax, displayMin, facet.status?.max, facet.status?.min]);
 
   // Update selected track styles
   useEffect(() => {

--- a/src/components/Filters/FilterRangeSlider.tsx
+++ b/src/components/Filters/FilterRangeSlider.tsx
@@ -144,19 +144,21 @@ export default function FilterRangeSlider(props: FilterRangeSliderProps) {
     }
   };
 
-  // Update internal state when facet status changes
+  // Sync internal state when facet range or status changes
   useEffect(() => {
-    if (facet.status?.min !== undefined) {
-      const clampedMin = Math.max(displayMin, Math.min(displayMax, facet.status.min));
-      setMinValue(clampedMin);
-      setInputMinValue(isSingleValue ? facet.status.min : clampedMin);
-    }
+    const clamp = (value: number) => Math.max(displayMin, Math.min(displayMax, value));
 
-    if (facet.status?.max !== undefined) {
-      const clampedMax = Math.max(displayMin, Math.min(displayMax, facet.status.max));
-      setMaxValue(clampedMax);
-      setInputMaxValue(isSingleValue ? facet.status.max : clampedMax);
-    }
+    const targetMin = facet.status?.min !== undefined ? clamp(facet.status.min) : displayMin;
+    const targetMax = facet.status?.max !== undefined ? clamp(facet.status.max) : displayMax;
+
+    setMinValue(targetMin);
+    setMaxValue(targetMax);
+    setInputMinValue(
+      isSingleValue && facet.status?.min !== undefined ? facet.status.min : targetMin,
+    );
+    setInputMaxValue(
+      isSingleValue && facet.status?.max !== undefined ? facet.status.max : targetMax,
+    );
   }, [
     facet.min,
     facet.max,
@@ -166,18 +168,6 @@ export default function FilterRangeSlider(props: FilterRangeSliderProps) {
     displayMax,
     isSingleValue,
   ]);
-
-  // Update internal state when facet's min/max change (e.g. due to another filter being applied)
-  useEffect(() => {
-    if (facet.status?.min === undefined) {
-      setMinValue(displayMin);
-      setInputMinValue(displayMin);
-    }
-    if (facet.status?.max === undefined) {
-      setMaxValue(displayMax);
-      setInputMaxValue(displayMax);
-    }
-  }, [displayMax, displayMin, facet.status?.max, facet.status?.min]);
 
   // Update selected track styles
   useEffect(() => {


### PR DESCRIPTION
# Pull Request Checklist

Before you submit a pull request, please make sure you have to following:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made sure my PR is up-to-date with the main branch.

# Testing

## With facet status

- Initial facet's min/max: `20`/`80`
- Initial facet's status min/max: `25`/`75`

1. When facet's min/max is changed to `30`/`40`, Silder and inputs should be correctly clamped
2. When facet's min/max is changed to `10`/`90`, Silder and inputs should be correctly updated to facet's status values

### Before

https://github.com/user-attachments/assets/b59c98b6-5243-463b-959e-dbb12015805b

### After

https://github.com/user-attachments/assets/211e48e7-c107-4d3a-b7ce-cd545052ca22

## Without facet status

- Initial facet's min/max: `20`/`50`

1. When facet's min/max is changed to `30`/`40`, Silder and inputs should be correctly clamped
2. When facet's min/max is changed back to `20`/`50`, Silder and inputs should be correctly updated to new min/max

### Before

1. When facet's min/max is changed to `30`/`40`, Silder and inputs ARE NOT correctly clamped
2. When facet's min/max is changed back to `20`/`50`, Silder and inputs ARE NOT correctly updated to new min/max

https://github.com/user-attachments/assets/8d0f1bc6-0c5e-46fe-af52-ae218c4a5354

### After

https://github.com/user-attachments/assets/16d33db5-8278-45eb-8e4a-471ce623d3e0

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] TypeScript type definitions update
- [ ] Other... Please describe:
