### PR TITLE
[NOCDX] Fix: Sort Component Visibility

### DIFF
--- a/src/components/Sort/Sort.css
+++ b/src/components/Sort/Sort.css
@@ -30,6 +30,7 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
+  z-index: 1;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Problem
* The current CSS is unintentionally hiding the `Sort` component on large screens 

## Changes
* Added `z-index: 1` to the `.cio-plp-sort .collapsible-content` class