### PR TITLE
[MT-3262] Support externally controlled FilterGroup/Groups expand/collapse state

### DIFF
--- a/spec/components/Filters/FilterGroup.test.jsx
+++ b/spec/components/Filters/FilterGroup.test.jsx
@@ -88,6 +88,37 @@ describe('Testing Component: FilterGroup', () => {
     expect(mockSetFilter).not.toHaveBeenCalled();
   });
 
+  it('Should render filter group collapsed when defaultCollapsed is true', () => {
+    const multipleFacet = {
+      displayName: 'Color',
+      name: 'color',
+      type: 'multiple',
+      data: {},
+      hidden: false,
+      options: [
+        { status: '', count: 10, displayName: 'Red', value: 'Red', data: {} },
+        { status: '', count: 5, displayName: 'Blue', value: 'Blue', data: {} },
+      ],
+    };
+
+    render(
+      <CioPlp apiKey={DEMO_API_KEY}>
+        <FilterGroup
+          facet={multipleFacet}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+          defaultCollapsed
+        />
+      </CioPlp>,
+    );
+
+    const arrow = screen
+      .getByText('Color')
+      .closest('.cio-filter-header')
+      .querySelector('.cio-arrow');
+    expect(arrow).toHaveClass('cio-arrow-up');
+  });
+
   it('Should render filter group collapsed when isCollapsedOverride is true', () => {
     const multipleFacet = {
       displayName: 'Color',

--- a/spec/components/Filters/FilterGroup.test.jsx
+++ b/spec/components/Filters/FilterGroup.test.jsx
@@ -88,7 +88,7 @@ describe('Testing Component: FilterGroup', () => {
     expect(mockSetFilter).not.toHaveBeenCalled();
   });
 
-  it('Should render filter group collapsed when defaultCollapsed is true', () => {
+  it('Should render filter group collapsed when isCollapsedOverride is true', () => {
     const multipleFacet = {
       displayName: 'Color',
       name: 'color',
@@ -107,7 +107,7 @@ describe('Testing Component: FilterGroup', () => {
           facet={multipleFacet}
           setFilter={mockSetFilter}
           initialNumOptions={10}
-          defaultCollapsed
+          isCollapsedOverride
         />
       </CioPlp>,
     );
@@ -119,7 +119,7 @@ describe('Testing Component: FilterGroup', () => {
     expect(arrow).toHaveClass('cio-arrow-up');
   });
 
-  it('Should render filter group expanded when defaultCollapsed is false', () => {
+  it('Should render filter group expanded when isCollapsedOverride is false', () => {
     const multipleFacet = {
       displayName: 'Color',
       name: 'color',
@@ -138,7 +138,7 @@ describe('Testing Component: FilterGroup', () => {
           facet={multipleFacet}
           setFilter={mockSetFilter}
           initialNumOptions={10}
-          defaultCollapsed={false}
+          isCollapsedOverride={false}
         />
       </CioPlp>,
     );
@@ -148,6 +148,106 @@ describe('Testing Component: FilterGroup', () => {
       .closest('.cio-filter-header')
       .querySelector('.cio-arrow');
     expect(arrow).toHaveClass('cio-arrow-down');
+  });
+
+  it('Should update isCollapsed when isCollapsedOverride prop changes after mount (externally controlled)', () => {
+    const multipleFacet = {
+      displayName: 'Color',
+      name: 'color',
+      type: 'multiple',
+      data: {},
+      hidden: false,
+      options: [
+        { status: '', count: 10, displayName: 'Red', value: 'Red', data: {} },
+        { status: '', count: 5, displayName: 'Blue', value: 'Blue', data: {} },
+      ],
+    };
+
+    const { rerender } = render(
+      <CioPlp apiKey={DEMO_API_KEY}>
+        <FilterGroup
+          facet={multipleFacet}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+          isCollapsedOverride={false}
+        />
+      </CioPlp>,
+    );
+
+    const getArrow = () =>
+      screen.getByText('Color').closest('.cio-filter-header').querySelector('.cio-arrow');
+
+    expect(getArrow()).toHaveClass('cio-arrow-down');
+
+    rerender(
+      <CioPlp apiKey={DEMO_API_KEY}>
+        <FilterGroup
+          facet={multipleFacet}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+          isCollapsedOverride
+        />
+      </CioPlp>,
+    );
+
+    expect(getArrow()).toHaveClass('cio-arrow-up');
+
+    rerender(
+      <CioPlp apiKey={DEMO_API_KEY}>
+        <FilterGroup
+          facet={multipleFacet}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+          isCollapsedOverride={false}
+        />
+      </CioPlp>,
+    );
+
+    expect(getArrow()).toHaveClass('cio-arrow-down');
+  });
+
+  it('Should not override a manual toggle when isCollapsedOverride has not changed', () => {
+    const multipleFacet = {
+      displayName: 'Color',
+      name: 'color',
+      type: 'multiple',
+      data: {},
+      hidden: false,
+      options: [
+        { status: '', count: 10, displayName: 'Red', value: 'Red', data: {} },
+        { status: '', count: 5, displayName: 'Blue', value: 'Blue', data: {} },
+      ],
+    };
+
+    const { rerender } = render(
+      <CioPlp apiKey={DEMO_API_KEY}>
+        <FilterGroup
+          facet={multipleFacet}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+          isCollapsedOverride={false}
+        />
+      </CioPlp>,
+    );
+
+    const header = screen.getByText('Color').closest('.cio-filter-header');
+    fireEvent.click(header);
+
+    const getArrow = () => header.querySelector('.cio-arrow');
+    expect(getArrow()).toHaveClass('cio-arrow-up');
+
+    rerender(
+      <CioPlp apiKey={DEMO_API_KEY}>
+        <FilterGroup
+          facet={multipleFacet}
+          setFilter={mockSetFilter}
+          initialNumOptions={10}
+          isCollapsedOverride={false}
+        />
+      </CioPlp>,
+    );
+
+    expect(getArrow()).toHaveClass('cio-arrow-up');
   });
 
   it('Should render range filter normally when min !== max', () => {

--- a/spec/components/Filters/Filters.test.jsx
+++ b/spec/components/Filters/Filters.test.jsx
@@ -1431,6 +1431,68 @@ describe('Testing Component: Filters', () => {
       });
     });
 
+    it('Should re-collapse/expand a filter group when its metadata-driven collapse state changes after mount (e.g. search match)', async () => {
+      const { getByText, rerender } = render(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Filters facets={mockFacetsWithMetadata} />
+        </CioPlp>,
+      );
+
+      await waitFor(() => {
+        // Color has cio_render_collapsed: true -> should be collapsed
+        const colorHeader = getByText('Color').closest('.cio-filter-group');
+        expect(isFilterGroupExpanded(colorHeader)).toBe(false);
+      });
+
+      // Simulate Color becoming a search match: cio_render_collapsed flips to false
+      const updatedFacets = mockFacetsWithMetadata.map((facet) =>
+        facet.name === 'color'
+          ? { ...facet, data: { ...facet.data, cio_render_collapsed: false } }
+          : facet,
+      );
+
+      rerender(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Filters facets={updatedFacets} />
+        </CioPlp>,
+      );
+
+      await waitFor(() => {
+        const colorHeader = getByText('Color').closest('.cio-filter-group');
+        expect(isFilterGroupExpanded(colorHeader)).toBe(true);
+      });
+    });
+
+    it('Should re-collapse a filter group when perFacetConfigs isCollapsed changes after mount', async () => {
+      const { getByText, rerender } = render(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Filters
+            facets={mockFacetsWithMetadata}
+            perFacetConfigs={{ size: { isCollapsed: false } }}
+          />
+        </CioPlp>,
+      );
+
+      await waitFor(() => {
+        const sizeHeader = getByText('Size').closest('.cio-filter-group');
+        expect(isFilterGroupExpanded(sizeHeader)).toBe(true);
+      });
+
+      rerender(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Filters
+            facets={mockFacetsWithMetadata}
+            perFacetConfigs={{ size: { isCollapsed: true } }}
+          />
+        </CioPlp>,
+      );
+
+      await waitFor(() => {
+        const sizeHeader = getByText('Size').closest('.cio-filter-group');
+        expect(isFilterGroupExpanded(sizeHeader)).toBe(false);
+      });
+    });
+
     it('Render props: getIsCollapsed should be available in render props', async () => {
       const mockChildren = jest.fn().mockReturnValue(<div>Custom Filters</div>);
 

--- a/spec/components/Groups/Groups.test.jsx
+++ b/spec/components/Groups/Groups.test.jsx
@@ -261,6 +261,59 @@ describe('Testing Component: Groups', () => {
     });
   });
 
+  describe(' - Externally controlled collapse state', () => {
+    it('Should update isCollapsed when the isCollapsed prop changes after mount', () => {
+      const { rerender } = render(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Groups {...groupsProps} isCollapsed={false} />
+        </CioPlp>,
+      );
+
+      const getArrow = () =>
+        screen.getByText('Categories').closest('.cio-filter-header').querySelector('.cio-arrow');
+
+      expect(getArrow()).toHaveClass('cio-arrow-down');
+
+      rerender(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Groups {...groupsProps} isCollapsed />
+        </CioPlp>,
+      );
+
+      expect(getArrow()).toHaveClass('cio-arrow-up');
+
+      rerender(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Groups {...groupsProps} isCollapsed={false} />
+        </CioPlp>,
+      );
+
+      expect(getArrow()).toHaveClass('cio-arrow-down');
+    });
+
+    it('Should not override a manual toggle when the isCollapsed prop has not changed', () => {
+      const { rerender } = render(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Groups {...groupsProps} isCollapsed={false} />
+        </CioPlp>,
+      );
+
+      const header = screen.getByText('Categories').closest('.cio-filter-header');
+      fireEvent.click(header);
+
+      const getArrow = () => header.querySelector('.cio-arrow');
+      expect(getArrow()).toHaveClass('cio-arrow-up');
+
+      rerender(
+        <CioPlp apiKey={DEMO_API_KEY}>
+          <Groups {...groupsProps} isCollapsed={false} />
+        </CioPlp>,
+      );
+
+      expect(getArrow()).toHaveClass('cio-arrow-up');
+    });
+  });
+
   describe(' - componentOverrides', () => {
     const overrideSlots = [
       {

--- a/src/components/Filters/FilterGroup.tsx
+++ b/src/components/Filters/FilterGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { IncludeComponentOverrides } from '@constructor-io/constructorio-ui-components';
 import type {
   PlpFacet,
@@ -31,7 +31,12 @@ export interface FilterGroupProps extends IncludeComponentOverrides<FilterGroupO
    * @returns boolean
    */
   isHiddenFilterOptionFn?: (option: PlpFacetOption) => boolean;
-  defaultCollapsed?: boolean;
+  /**
+   * Whether the filter group should be collapsed. Used both as the initial value
+   * and to keep the collapsed state in sync when the value changes after mount,
+   * allowing it to be driven externally (e.g. by search matches).
+   */
+  isCollapsedOverride?: boolean;
   getVisualImageUrl?: (option: PlpFacetOption) => string | undefined;
   getVisualColorHex?: (option: PlpFacetOption) => string | undefined;
   isVisualFilterFn?: (facet: PlpFacet) => boolean;
@@ -46,7 +51,7 @@ export default function FilterGroup(props: FilterGroupProps) {
     sliderStep,
     facetSliderSteps,
     isHiddenFilterOptionFn,
-    defaultCollapsed = false,
+    isCollapsedOverride = false,
     getVisualImageUrl,
     getVisualColorHex,
     isVisualFilterFn,
@@ -55,7 +60,12 @@ export default function FilterGroup(props: FilterGroupProps) {
   } = props;
   const context = useCioPlpContext();
   const componentOverrides = componentOverridesProp ?? context?.componentOverrides?.filterGroup;
-  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const [isCollapsed, setIsCollapsed] = useState(isCollapsedOverride);
+
+  useEffect(() => {
+    setIsCollapsed(isCollapsedOverride);
+  }, [isCollapsedOverride]);
+
   const isVisual = shouldRenderVisualFacet(facet, perFacetConfigs, isVisualFilterFn);
   const checkboxPosition = perFacetConfigs?.[facet.name]?.checkboxPosition;
 

--- a/src/components/Filters/FilterGroup.tsx
+++ b/src/components/Filters/FilterGroup.tsx
@@ -32,9 +32,13 @@ export interface FilterGroupProps extends IncludeComponentOverrides<FilterGroupO
    */
   isHiddenFilterOptionFn?: (option: PlpFacetOption) => boolean;
   /**
+   * @deprecated Use `isCollapsedOverride` instead.
+   */
+  defaultCollapsed?: boolean;
+  /**
    * Whether the filter group should be collapsed. Used both as the initial value
    * and to keep the collapsed state in sync when the value changes after mount,
-   * allowing it to be driven externally (e.g. by search matches).
+   * allowing it to be driven externally.
    */
   isCollapsedOverride?: boolean;
   getVisualImageUrl?: (option: PlpFacetOption) => string | undefined;
@@ -51,7 +55,8 @@ export default function FilterGroup(props: FilterGroupProps) {
     sliderStep,
     facetSliderSteps,
     isHiddenFilterOptionFn,
-    isCollapsedOverride = false,
+    defaultCollapsed,
+    isCollapsedOverride,
     getVisualImageUrl,
     getVisualColorHex,
     isVisualFilterFn,
@@ -60,10 +65,12 @@ export default function FilterGroup(props: FilterGroupProps) {
   } = props;
   const context = useCioPlpContext();
   const componentOverrides = componentOverridesProp ?? context?.componentOverrides?.filterGroup;
-  const [isCollapsed, setIsCollapsed] = useState(isCollapsedOverride);
+  const [isCollapsed, setIsCollapsed] = useState(isCollapsedOverride ?? defaultCollapsed ?? false);
 
   useEffect(() => {
-    setIsCollapsed(isCollapsedOverride);
+    if (isCollapsedOverride !== undefined) {
+      setIsCollapsed(isCollapsedOverride);
+    }
   }, [isCollapsedOverride]);
 
   const isVisual = shouldRenderVisualFacet(facet, perFacetConfigs, isVisualFilterFn);

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -62,7 +62,7 @@ export default function Filters(props: FiltersWithRenderProps) {
               getVisualColorHex={getVisualColorHex}
               isVisualFilterFn={isVisualFilterFn}
               perFacetConfigs={perFacetConfigs}
-              defaultCollapsed={getIsCollapsed(facet)}
+              isCollapsedOverride={getIsCollapsed(facet)}
               key={facet.name}
             />
           ))}

--- a/src/components/Groups/Groups.tsx
+++ b/src/components/Groups/Groups.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import {
   FilterOption,
@@ -59,6 +59,10 @@ export default function Groups(props: GroupsWithRenderProps) {
   } = useGroupsReturn;
 
   const [isCollapsed, setIsCollapsed] = useState(isCollapsedDefault);
+
+  useEffect(() => {
+    setIsCollapsed(isCollapsedDefault);
+  }, [isCollapsedDefault]);
 
   const toggleIsCollapsed = () => setIsCollapsed((prev) => !prev);
 

--- a/src/components/Groups/Groups.tsx
+++ b/src/components/Groups/Groups.tsx
@@ -15,7 +15,7 @@ import { translate } from '../../utils/helpers';
  */
 export interface GroupsProps extends UseGroupProps, IncludeComponentOverrides<GroupsOverrides> {
   /**
-   * Initial collapsed state of the groups filter panel
+   * Controls the collapsed state of the groups filter panel
    * @default false
    */
   isCollapsed?: boolean;


### PR DESCRIPTION
## Summary

`FilterGroup` and `Groups` previously used their collapse-related prop only to initialize local `isCollapsed` state via `useState`. Once mounted, later prop changes were ignored.

- `FilterGroup.tsx` / `Groups.tsx` now sync their internal `isCollapsed` state via `useEffect` whenever the collapse prop value changes, so external state changes are reflected after mount. Manual user toggles are unaffected as long as the prop value itself doesn't change.
- Renamed `FilterGroup`'s `defaultCollapsed` prop to `isCollapsedOverride` since it's no longer just an initializer. `FilterGroup` is **not** part of the public API (only rendered internally by `Filters.tsx`), so this is not a breaking change — the public `defaultCollapsed` prop on `Filters`/`useFilter`/`filterConfigs` is untouched.

## Why no Storybook stories were added

Existing stories for `Filters` and `Groups` only exercise their public `defaultCollapsed`/`isCollapsed` props, which are unrelated to the renamed internal `isCollapsedOverride` prop, so the rename has no story-visible impact. This repo's stories are static per-args snapshots (no story simulates a prop changing mid-session), and building an interactive demo purely to show "component now reacts to a changing prop" felt like more scaffolding than the fix warrants for a correctness bug. The behavior is instead covered by unit tests that simulate a re-render with a changed prop, which is the right layer for regression coverage (see test plan below).

## Test plan
- [x] `spec/components/Filters/FilterGroup.test.jsx` — added tests asserting `isCollapsed` resyncs when `isCollapsedOverride` changes after mount, and that manual toggles aren't clobbered by unrelated re-renders
- [x] `spec/components/Groups/Groups.test.jsx` — same coverage for `Groups`' `isCollapsed` prop
- [x] `spec/components/Filters/Filters.test.jsx` — added tests verifying `Filters` forces a `FilterGroup` to re-collapse/expand when `getIsCollapsed(facet)` changes after mount, via both facet metadata (`cio_render_collapsed`) and `perFacetConfigs`
- [x] Full test suite, `npm run lint`, `npm run check-types` all pass

Linear: https://linear.app/constructor/issue/MT-3262/support-externally-controlled-facetgroup-expand-collapse-state